### PR TITLE
Add client to handle different configuration servers

### DIFF
--- a/third_party/forked/afex/hystrix-go/hystrix/metrics.go
+++ b/third_party/forked/afex/hystrix-go/hystrix/metrics.go
@@ -87,7 +87,7 @@ func (m *metricExchange) IncrementMetrics(wg *sync.WaitGroup, collector metricCo
 		collector.IncrementShortCircuits()
 
 		collector.IncrementAttempts()
-		collector.IncrementErrors()
+		//collector.IncrementErrors()
 	}
 	if update.Types[0] == "timeout" {
 		collector.IncrementTimeouts()


### PR DESCRIPTION
Note : The CI will fail as the https://github.com/ServiceComb/go-cc-client/pull/8 & https://github.com/ServiceComb/go-archaius/pull/17 needs to be merged first and then their commit ID's needs to be updated in `vendor/mainfest`