### PR TITLE
bug fix: panic if call Done for multiple times,  if there is err clear the ctx

### DIFF
--- a/client/highway/highway_base_client.go
+++ b/client/highway/highway_base_client.go
@@ -252,12 +252,8 @@ func (baseClient *BaseClient) Send(req *Request, rsp *Response, timeout time.Dur
 		}
 
 		baseClient.RemoveWaitMsg(msgID)
-
 		if bTimeout {
 			ctx.Done()
-		}
-
-		if bTimeout {
 			rsp.Err = "Client send timeout"
 			return errors.New("Client send timeout")
 		}

--- a/client/highway/highway_base_client.go
+++ b/client/highway/highway_base_client.go
@@ -232,7 +232,7 @@ func (baseClient *BaseClient) Send(req *Request, rsp *Response, timeout time.Dur
 	}
 	if req.TwoWay {
 		wait := make(chan int)
-		ctx := &InvocationContext{Req:req, Rsp:rsp, Wait:&wait}
+		ctx := &InvocationContext{Req: req, Rsp: rsp, Wait: &wait}
 		baseClient.AddWaitMsg(msgID, ctx)
 
 		err := highwayConn.AsyncSendMsg(ctx)

--- a/client/highway/highway_base_client.go
+++ b/client/highway/highway_base_client.go
@@ -40,11 +40,14 @@ type InvocationContext struct {
 	Req  *Request
 	Rsp  *Response
 	Wait *chan int
+	once sync.Once
 }
 
 //Done Notify done.
 func (ctx *InvocationContext) Done() {
-	*ctx.Wait <- 1
+	ctx.once.Do(func() {
+		close(*ctx.Wait)
+	})
 }
 
 //ClientMgr client manage
@@ -229,11 +232,12 @@ func (baseClient *BaseClient) Send(req *Request, rsp *Response, timeout time.Dur
 	}
 	if req.TwoWay {
 		wait := make(chan int)
-		ctx := &InvocationContext{req, rsp, &wait}
+		ctx := &InvocationContext{Req:req, Rsp:rsp, Wait:&wait}
 		baseClient.AddWaitMsg(msgID, ctx)
 
 		err := highwayConn.AsyncSendMsg(ctx)
 		if err != nil {
+			baseClient.RemoveWaitMsg(msgID)
 			rsp.Err = err.Error()
 			lager.Logger.Error("AsyncSendMsg err:", err)
 			return err
@@ -248,7 +252,11 @@ func (baseClient *BaseClient) Send(req *Request, rsp *Response, timeout time.Dur
 		}
 
 		baseClient.RemoveWaitMsg(msgID)
-		close(wait)
+
+		if bTimeout {
+			ctx.Done()
+		}
+
 		if bTimeout {
 			rsp.Err = "Client send timeout"
 			return errors.New("Client send timeout")


### PR DESCRIPTION
问题：Wait管道处理有问题，违反管道处理原则（发送方关闭管道），当吞吐量达到5000以上时，有可能报以下错误
panic: send on closed channel

goroutine 144 [running]:
github.com/go-chassis/go-chassis/client/highway.(*InvocationContext).Done(...)
	/Users/heavyrainlee/go/src/github.com/go-chassis/go-chassis/client/highway/highway_base_client.go:47
github.com/go-chassis/go-chassis/client/highway.(*ClientConnection).processMsg(0xc420350140, 0xc42cb63860)
	/Users/heavyrainlee/go/src/github.com/go-chassis/go-chassis/client/highway/client_conn.go:100 +0x8c
github.com/go-chassis/go-chassis/client/highway.(*ClientConnection).msgRecvLoop(0xc420350140)
	/Users/heavyrainlee/go/src/github.com/go-chassis/go-chassis/client/highway/client_conn.go:91 +0xd3
created by github.com/go-chassis/go-chassis/client/highway.(*ClientConnection).Open
	/Users/heavyrainlee/go/src/github.com/go-chassis/go-chassis/client/highway/client_conn.go:44 +0x96

原因：有多个地方调用Done方法，Done方法向管道写入-1，然后另外一个go程再读到这个值或者超时时关闭wait。如果有多个写入或者超时，就有可能最后一个写入的遇到关闭的管道
处理方法：Done内关闭，为了防止多次调用Done或超时去关闭，使用Once方法。

2，当highwayConn.AsyncSendMsg返回错误时，没有清除掉等待上下文