### PR TITLE
alter ReceiveData function

### DIFF
--- a/core/loadbalancer/latency_strategy.go
+++ b/core/loadbalancer/latency_strategy.go
@@ -131,7 +131,7 @@ func newWeightedResponseStrategy() Strategy {
 // ReceiveData receive data
 func (r *WeightedResponseStrategy) ReceiveData(instances []*registry.MicroServiceInstance, serviceKey, protocol, sessionID string) {
 	r.instances = instances
-	r.serviceName = strings.Split(serviceKey, ":")[0]
+	r.serviceName = strings.Split(serviceKey, "|")[0]
 	r.protocol = protocol
 }
 

--- a/core/loadbalancer/struct.go
+++ b/core/loadbalancer/struct.go
@@ -25,7 +25,7 @@ func (ps *ProtocolStats) CalculateAverageLatency() {
 
 // SaveLatency save latest 10 record
 func (ps *ProtocolStats) SaveLatency(l time.Duration) {
-	if len(ps.Latency) > 10 {
+	if len(ps.Latency) >= 10 {
 		//save latest 10 latencies
 		ps.Latency = ps.Latency[1:]
 	}


### PR DESCRIPTION
ReceiveData function use Separator of ":"   split  serviceKey，But the incoming parameter serviceKey is spliced using "|" ，The will one more “|” character after serviceName ， so  alter Separator  of “|” in ReceiveData function to split  serviceKey。 SaveLatency save latest 10 record,but save latest 11