### PR TITLE
Bugfix: fix provider's endpoint registered to service center

### DIFF
--- a/core/registry/util.go
+++ b/core/registry/util.go
@@ -98,7 +98,7 @@ func MakeEndpointMap(m map[string]model.Protocol) (map[string]string, error) {
 func fillUnspecifiedIp(host string) (string, error) {
 	var ipaddr string
 	ip := net.ParseIP(host)
-	if ip != nil {
+	if ip == nil {
 		return "", fmt.Errorf("invalid IP address %s", host)
 	}
 

--- a/core/registry/util.go
+++ b/core/registry/util.go
@@ -96,24 +96,24 @@ func MakeEndpointMap(m map[string]model.Protocol) (map[string]string, error) {
 
 // fillUnspecifiedIp Replace 0.0.0.0 or :: IPv4 and IPv6 unspecified IP address with local NIC IP.
 func fillUnspecifiedIp(host string) (string, error) {
-	var ipaddr string
+	var addr string
 	ip := net.ParseIP(host)
 	if ip == nil {
 		return "", fmt.Errorf("invalid IP address %s", host)
 	}
 
-	ipaddr = host
+	addr = host
 	if ip.IsUnspecified() {
 		if iputil.IsIPv6Address(ip) {
-			ipaddr = iputil.GetLocalIPv6()
+			addr = iputil.GetLocalIPv6()
 		} else {
-			ipaddr = iputil.GetLocalIP()
+			addr = iputil.GetLocalIP()
 		}
-		if len(ipaddr) == 0 {
-			return ipaddr, fmt.Errorf("failed to get local IP address")
+		if len(addr) == 0 {
+			return addr, fmt.Errorf("failed to get local IP address")
 		}
 	}
-	return ipaddr, nil
+	return addr, nil
 }
 
 //Microservice2ServiceKeyStr prepares a microservice key

--- a/core/registry/util.go
+++ b/core/registry/util.go
@@ -85,7 +85,7 @@ func MakeEndpointMap(m map[string]model.Protocol) (map[string]string, error) {
 			return nil, fmt.Errorf("listen address is invalid [%s]", protocol.Listen)
 		}
 
-		ip, err := fillUnspecifiedIp(host)
+		ip, err := fillUnspecifiedIP(host)
 		if err != nil {
 			return nil, err
 		}
@@ -94,8 +94,8 @@ func MakeEndpointMap(m map[string]model.Protocol) (map[string]string, error) {
 	return eps, nil
 }
 
-// fillUnspecifiedIp Replace 0.0.0.0 or :: IPv4 and IPv6 unspecified IP address with local NIC IP.
-func fillUnspecifiedIp(host string) (string, error) {
+// fillUnspecifiedIP replace 0.0.0.0 or :: IPv4 and IPv6 unspecified IP address with local NIC IP.
+func fillUnspecifiedIP(host string) (string, error) {
 	var addr string
 	ip := net.ParseIP(host)
 	if ip == nil {

--- a/core/registry/util2_test.go
+++ b/core/registry/util2_test.go
@@ -12,11 +12,11 @@ func Test_fillUnspecifiedIp(t *testing.T) {
 	assert.NotEmpty(t, ipaddr)
 	assert.NotEqual(t, ipaddr, host)
 
-	host = "::"
-	ipaddr, err = fillUnspecifiedIp(host)
-	assert.NoError(t, err)
-	assert.NotEmpty(t, ipaddr)
-	assert.NotEqual(t, ipaddr, host)
+	//host = "::"	// IPv6 address needed for local NIC
+	//ipaddr, err = fillUnspecifiedIp(host)
+	//assert.NoError(t, err)
+	//assert.NotEmpty(t, ipaddr)
+	//assert.NotEqual(t, ipaddr, host)
 
 	host = "114.116.58.51"
 	ipaddr, err = fillUnspecifiedIp(host)

--- a/core/registry/util2_test.go
+++ b/core/registry/util2_test.go
@@ -7,28 +7,28 @@ import (
 
 func Test_fillUnspecifiedIp(t *testing.T) {
 	host := "0.0.0.0"
-	ipaddr, err := fillUnspecifiedIp(host)
+	ipaddr, err := fillUnspecifiedIP(host)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, ipaddr)
 	assert.NotEqual(t, ipaddr, host)
 
 	//host = "::"	// IPv6 address needed for local NIC
-	//ipaddr, err = fillUnspecifiedIp(host)
+	//ipaddr, err = fillUnspecifiedIP(host)
 	//assert.NoError(t, err)
 	//assert.NotEmpty(t, ipaddr)
 	//assert.NotEqual(t, ipaddr, host)
 
 	host = "114.116.58.51"
-	ipaddr, err = fillUnspecifiedIp(host)
+	ipaddr, err = fillUnspecifiedIP(host)
 	assert.NoError(t, err)
 	assert.Equal(t, host, ipaddr)
 
 	host = "fe80::c706:e006:d53e:f9fb"
-	ipaddr, err = fillUnspecifiedIp(host)
+	ipaddr, err = fillUnspecifiedIP(host)
 	assert.NoError(t, err)
 	assert.Equal(t, host, ipaddr)
 
 	host = "abc"
-	ipaddr, err = fillUnspecifiedIp(host)
+	ipaddr, err = fillUnspecifiedIP(host)
 	assert.Equal(t, "", ipaddr)
 }

--- a/core/registry/util2_test.go
+++ b/core/registry/util2_test.go
@@ -1,0 +1,34 @@
+package registry
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func Test_fillUnspecifiedIp(t *testing.T) {
+	host := "0.0.0.0"
+	ipaddr, err := fillUnspecifiedIp(host)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, ipaddr)
+	assert.NotEqual(t, ipaddr, host)
+
+	host = "::"
+	ipaddr, err = fillUnspecifiedIp(host)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, ipaddr)
+	assert.NotEqual(t, ipaddr, host)
+
+	host = "114.116.58.51"
+	ipaddr, err = fillUnspecifiedIp(host)
+	assert.NoError(t, err)
+	assert.Equal(t, host, ipaddr)
+
+	host = "fe80::c706:e006:d53e:f9fb"
+	ipaddr, err = fillUnspecifiedIp(host)
+	assert.NoError(t, err)
+	assert.Equal(t, host, ipaddr)
+
+	host = "abc"
+	ipaddr, err = fillUnspecifiedIp(host)
+	assert.Equal(t, "", ipaddr)
+}

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/go-logfmt/logfmt v0.4.0 // indirect
 	github.com/go-mesh/openlogging v0.0.0-20181122085847-3daf3ad8ed35
 	github.com/gogo/protobuf v1.2.0 // indirect
-	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b // indirect
 	github.com/golang/protobuf v1.2.0
 	github.com/hashicorp/go-version v1.0.0
 	github.com/onsi/ginkgo v1.7.0 // indirect
@@ -31,8 +30,9 @@ require (
 	github.com/stretchr/testify v1.2.2
 	github.com/uber-go/atomic v1.3.2 // indirect
 	go.uber.org/ratelimit v0.0.0-20180316092928-c15da0234277
-	golang.org/x/net v0.0.0-20180906233101-161cd47e91fd
-	google.golang.org/grpc v1.14.0
+	golang.org/x/net v0.0.0-20181106065722-10aee1819953
+	google.golang.org/genproto v0.0.0-20181221175505-bd9b4fb69e2f // indirect
+	google.golang.org/grpc v1.16.0
 	gopkg.in/yaml.v2 v2.2.1
 )
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/go-chassis/go-chassis
 require (
 	github.com/DataDog/zstd v1.3.4 // indirect
 	github.com/Shopify/sarama v1.20.0 // indirect
-	github.com/Shopify/toxiproxy v2.1.3+incompatible // indirect
 	github.com/apache/thrift v0.0.0-20180829120307-8de3749235db
 	github.com/cenkalti/backoff v2.0.0+incompatible
 	github.com/emicklei/go-restful v2.8.0+incompatible
@@ -17,8 +16,6 @@ require (
 	github.com/gogo/protobuf v1.2.0 // indirect
 	github.com/golang/protobuf v1.2.0
 	github.com/hashicorp/go-version v1.0.0
-	github.com/onsi/ginkgo v1.7.0 // indirect
-	github.com/onsi/gomega v1.4.3 // indirect
 	github.com/opentracing/opentracing-go v1.0.2
 	github.com/openzipkin-contrib/zipkin-go-opentracing v0.0.0-20180726151020-b85dc675b16b
 	github.com/patrickmn/go-cache v2.1.0+incompatible
@@ -28,25 +25,17 @@ require (
 	github.com/rcrowley/go-metrics v0.0.0-20180503174638-e2704e165165
 	github.com/smartystreets/goconvey v0.0.0-20170602164621-9e8dc3f972df
 	github.com/stretchr/testify v1.2.2
-	github.com/uber-go/atomic v1.3.2 // indirect
 	go.uber.org/ratelimit v0.0.0-20180316092928-c15da0234277
-	golang.org/x/net v0.0.0-20181106065722-10aee1819953
-	google.golang.org/genproto v0.0.0-20181221175505-bd9b4fb69e2f // indirect
-	google.golang.org/grpc v1.16.0
+	google.golang.org/grpc v1.14.0
 	gopkg.in/yaml.v2 v2.2.1
 )
 
 replace (
 	golang.org/x/crypto v0.0.0-20180820150726-614d502a4dac => github.com/golang/crypto v0.0.0-20180820150726-614d502a4dac
 	golang.org/x/net v0.0.0-20180824152047-4bcd98cce591 => github.com/golang/net v0.0.0-20180824152047-4bcd98cce591
-	golang.org/x/net v0.0.0-20180906233101-161cd47e91fd => github.com/golang/net v0.0.0-20180906233101-161cd47e91fd
-
-	golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f => github.com/golang/sync v0.0.0-20180314180146-1d60e4601c6f
 	golang.org/x/sys v0.0.0-20180824143301-4910a1d54f87 => github.com/golang/sys v0.0.0-20180824143301-4910a1d54f87
-	golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e => github.com/golang/sys v0.0.0-20180909124046-d0be0721c37e
 	golang.org/x/text v0.3.0 => github.com/golang/text v0.3.0
 	golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2 => github.com/golang/time v0.0.0-20180412165947-fbb02b2291d2
 	google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8 => github.com/google/go-genproto v0.0.0-20180817151627-c66870c02cf8
-	google.golang.org/genproto v0.0.0-20181221175505-bd9b4fb69e2f => github.com/google/go-genproto v0.0.0-20181221175505-bd9b4fb69e2f
 	google.golang.org/grpc v1.14.0 => github.com/grpc/grpc-go v1.14.0
 )

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/go-chassis/go-chassis
 require (
 	github.com/DataDog/zstd v1.3.4 // indirect
 	github.com/Shopify/sarama v1.20.0 // indirect
+	github.com/Shopify/toxiproxy v2.1.3+incompatible // indirect
 	github.com/apache/thrift v0.0.0-20180829120307-8de3749235db
 	github.com/cenkalti/backoff v2.0.0+incompatible
 	github.com/emicklei/go-restful v2.8.0+incompatible
@@ -14,8 +15,11 @@ require (
 	github.com/go-logfmt/logfmt v0.4.0 // indirect
 	github.com/go-mesh/openlogging v0.0.0-20181122085847-3daf3ad8ed35
 	github.com/gogo/protobuf v1.2.0 // indirect
+	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b // indirect
 	github.com/golang/protobuf v1.2.0
 	github.com/hashicorp/go-version v1.0.0
+	github.com/onsi/ginkgo v1.7.0 // indirect
+	github.com/onsi/gomega v1.4.3 // indirect
 	github.com/opentracing/opentracing-go v1.0.2
 	github.com/openzipkin-contrib/zipkin-go-opentracing v0.0.0-20180726151020-b85dc675b16b
 	github.com/patrickmn/go-cache v2.1.0+incompatible
@@ -25,7 +29,9 @@ require (
 	github.com/rcrowley/go-metrics v0.0.0-20180503174638-e2704e165165
 	github.com/smartystreets/goconvey v0.0.0-20170602164621-9e8dc3f972df
 	github.com/stretchr/testify v1.2.2
+	github.com/uber-go/atomic v1.3.2 // indirect
 	go.uber.org/ratelimit v0.0.0-20180316092928-c15da0234277
+	golang.org/x/net v0.0.0-20180906233101-161cd47e91fd
 	google.golang.org/grpc v1.14.0
 	gopkg.in/yaml.v2 v2.2.1
 )
@@ -33,9 +39,14 @@ require (
 replace (
 	golang.org/x/crypto v0.0.0-20180820150726-614d502a4dac => github.com/golang/crypto v0.0.0-20180820150726-614d502a4dac
 	golang.org/x/net v0.0.0-20180824152047-4bcd98cce591 => github.com/golang/net v0.0.0-20180824152047-4bcd98cce591
+	golang.org/x/net v0.0.0-20180906233101-161cd47e91fd => github.com/golang/net v0.0.0-20180906233101-161cd47e91fd
+
+	golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f => github.com/golang/sync v0.0.0-20180314180146-1d60e4601c6f
 	golang.org/x/sys v0.0.0-20180824143301-4910a1d54f87 => github.com/golang/sys v0.0.0-20180824143301-4910a1d54f87
+	golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e => github.com/golang/sys v0.0.0-20180909124046-d0be0721c37e
 	golang.org/x/text v0.3.0 => github.com/golang/text v0.3.0
 	golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2 => github.com/golang/time v0.0.0-20180412165947-fbb02b2291d2
 	google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8 => github.com/google/go-genproto v0.0.0-20180817151627-c66870c02cf8
+	google.golang.org/genproto v0.0.0-20181221175505-bd9b4fb69e2f => github.com/google/go-genproto v0.0.0-20181221175505-bd9b4fb69e2f
 	google.golang.org/grpc v1.14.0 => github.com/grpc/grpc-go v1.14.0
 )

--- a/pkg/util/iputil/ip.go
+++ b/pkg/util/iputil/ip.go
@@ -24,8 +24,8 @@ func GetLocalIP() string {
 		if ip, _, err = net.ParseCIDR(address.String()); err != nil {
 			return ""
 		}
-		// Check if Isloopback and IPV4
-		if ip != nil && !ip.IsLoopback() && (ip.To4() != nil) {
+		// Check if valid global unicast IPv4 address
+		if ip != nil && (ip.To4() != nil) && ip.IsGlobalUnicast() {
 			return ip.String()
 		}
 	}
@@ -85,8 +85,8 @@ func GetLocalIPv6() string {
 		if ip, _, err = net.ParseCIDR(address.String()); err != nil {
 			return ""
 		}
-		// Check if Isloopback and IPV4
-		if ip != nil && !ip.IsLoopback() && (ip.To16() != nil) && IsIPv6Address(ip) {
+		// Check if valid IPv6 address
+		if ip != nil && (ip.To16() != nil) && IsIPv6Address(ip) && ip.IsGlobalUnicast() {
 			return ip.String()
 		}
 	}

--- a/pkg/util/iputil/ip.go
+++ b/pkg/util/iputil/ip.go
@@ -72,3 +72,30 @@ func URIs2Hosts(uris []string) ([]string, string, error) {
 	}
 	return hosts, scheme, nil
 }
+
+//GetLocalIP Get IPv6 address of NIC.
+func GetLocalIPv6() string {
+	addresses, err := net.InterfaceAddrs()
+	if err != nil {
+		return ""
+	}
+	for _, address := range addresses {
+		// Parse IP
+		var ip net.IP
+		if ip, _, err = net.ParseCIDR(address.String()); err != nil {
+			return ""
+		}
+		// Check if Isloopback and IPV4
+		if ip != nil && !ip.IsLoopback() && (ip.To16() != nil) && IsIPv6Address(ip) {
+			return ip.String()
+		}
+	}
+	return ""
+}
+
+func IsIPv6Address(ip net.IP) bool {
+	if ip != nil && strings.Contains(ip.String(), ":") {
+		return true
+	}
+	return false
+}

--- a/pkg/util/iputil/ip.go
+++ b/pkg/util/iputil/ip.go
@@ -73,7 +73,7 @@ func URIs2Hosts(uris []string) ([]string, string, error) {
 	return hosts, scheme, nil
 }
 
-//GetLocalIP Get IPv6 address of NIC.
+//GetLocalIPv6 Get IPv6 address of NIC.
 func GetLocalIPv6() string {
 	addresses, err := net.InterfaceAddrs()
 	if err != nil {
@@ -93,6 +93,7 @@ func GetLocalIPv6() string {
 	return ""
 }
 
+// IsIPv6Address check whether the IP is IPv6 address.
 func IsIPv6Address(ip net.IP) bool {
 	if ip != nil && strings.Contains(ip.String(), ":") {
 		return true

--- a/pkg/util/iputil/ip_test.go
+++ b/pkg/util/iputil/ip_test.go
@@ -4,6 +4,7 @@ import (
 	"github.com/go-chassis/go-chassis/core/common"
 	"github.com/go-chassis/go-chassis/pkg/util/iputil"
 	"github.com/stretchr/testify/assert"
+	"net"
 	"testing"
 )
 
@@ -41,3 +42,14 @@ func TestDefaultPort4ProtocolNone(t *testing.T) {
 //	_,err =http.DefaultClient.Get("http://[fe80::7f28:7160:56cd:3ec9]:5001")
 //	assert.NoError(t,err)
 //}
+
+func Test_IsIPv6Address(t *testing.T) {
+	assert.True(t, false == iputil.IsIPv6Address(nil))
+	assert.True(t, false == iputil.IsIPv6Address(net.ParseIP("abc")))
+	assert.True(t, true == iputil.IsIPv6Address(net.ParseIP("::")))
+	assert.True(t, true == iputil.IsIPv6Address(net.ParseIP("::")))
+	assert.True(t, true == iputil.IsIPv6Address(net.ParseIP("fe80::c706:e006:d53e:f9fb")))
+	assert.True(t, true == iputil.IsIPv6Address(net.ParseIP("fe80::10.25.21.2")))
+	assert.True(t, false == iputil.IsIPv6Address(net.ParseIP("10.25.21.2")))
+	assert.True(t, false == iputil.IsIPv6Address(net.ParseIP("0.0.0.0")))
+}


### PR DESCRIPTION
When provider listening on *all IP*, go-chassis will register `0.0.0.0` to service center, but consumer should know the specified IP address instead `0.0.0.0`, otherwise the consumer calls will go failure.
This PR fixes the logic when provider config `0.0.0.0` as the `listenAddress` or `advertiseAddress` in `chassis.yaml`, one of local NIC's IP address will be used when registering to service center.

For `iputil.GetLocalIP()`, use `IsGlobalUnicast()` to filter local loopback / local unicast or unspecified addresses out.