### PR TITLE
report ip address instead of hostname to service center when specify service_description.hostname: 0.0.0.0

### DIFF
--- a/core/config/config.go
+++ b/core/config/config.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-chassis/go-chassis/core/config/schema"
 	"github.com/go-chassis/go-chassis/core/lager"
 	"github.com/go-chassis/go-chassis/pkg/util/fileutil"
+	"github.com/go-chassis/go-chassis/pkg/util/iputil"
 
 	"github.com/go-chassis/go-chassis/pkg/runtime"
 	"github.com/go-mesh/openlogging"
@@ -338,6 +339,8 @@ func Init() error {
 			lager.Logger.Error("Get hostname failed:" + err.Error())
 			return err
 		}
+	} else if runtime.HostName == "0.0.0.0" {
+		runtime.HostName = iputil.GetLocalIP()
 	}
 	lager.Logger.Info("Host name is " + runtime.HostName)
 	return err


### PR DESCRIPTION
in our k8s cluster, docker hostname some time are the same, so we could not recognize the real endpoint of that microservice instance from service center, in this scene we need to report docker ip to service center。i add a judge when service_description.hostname=0.0.0.0 then go-chassis report host ip address to service center