### PR TITLE
Using random port to start server

### DIFF
--- a/core/registry/bootstrap.go
+++ b/core/registry/bootstrap.go
@@ -18,7 +18,7 @@ var errEmptyServiceIDFromRegistry = errors.New("got empty serviceID from registr
 var microServiceDependencies *MicroServiceDependency
 
 // InstanceEndpoints instance endpoints
-var InstanceEndpoints map[string]string
+var InstanceEndpoints = make(map[string]string)
 
 // RegisterMicroservice register micro-service
 func RegisterMicroservice() error {

--- a/core/server/server_test.go
+++ b/core/server/server_test.go
@@ -39,6 +39,7 @@ func TestWithOptions(t *testing.T) {
 
 const MockError = "movk error"
 
+// TestSrcMgr Test for server_manager.go
 func TestSrcMgr(t *testing.T) {
 
 	gopath := os.Getenv("GOPATH")
@@ -78,7 +79,9 @@ func TestSrcMgr(t *testing.T) {
 	defaultChain["default1"] = ""
 
 	var mp model.Protocol
-	mp.Listen = "127.0.0.1:30100"
+	//mp.Listen = "127.0.0.1:30100"
+	// use random port
+	mp.Listen = "127.0.0.1:0"
 	mp.Advertise = "127.0.0.1:8080"
 	mp.WorkerNumber = 10
 	mp.Transport = "tcp"


### PR DESCRIPTION
For Issue #524
Ability to use random port to start server, just using :0 as port, example:
`listenAddress: 0.0.0.0:0`
允许使用随机端口监听服务，该修改已可以满足当前使用，未大幅度更改当前启动机制，请检视代码以确认代码更改合理性