### PR TITLE
bug fix: can not register the same prefix protocol

### DIFF
--- a/core/registry/bootstrap.go
+++ b/core/registry/bootstrap.go
@@ -133,7 +133,7 @@ func RegisterMicroserviceInstances() error {
 		return err
 	}
 	lager.Logger.Infof("service support protocols %v", config.GlobalDefinition.Cse.Protocols)
-	if InstanceEndpoints != nil {
+	if len(InstanceEndpoints) != 0 {
 		eps = InstanceEndpoints
 	}
 	if service.ServiceDescription.ServicesStatus == "" {

--- a/core/registry/heartbeat.go
+++ b/core/registry/heartbeat.go
@@ -162,7 +162,7 @@ func reRegisterSelfMSI(sid, iid string) error {
 	if err != nil {
 		return err
 	}
-	if InstanceEndpoints != nil {
+	if len(InstanceEndpoints) != 0 {
 		eps = InstanceEndpoints
 	}
 	microServiceInstance := &MicroServiceInstance{

--- a/core/server/options.go
+++ b/core/server/options.go
@@ -8,10 +8,11 @@ import (
 
 //Options is the options for service initiating
 type Options struct {
-	Address   string
-	ChainName string
-	Provider  provider.Provider
-	TLSConfig *tls.Config
+	Address            string
+	ProtocolServerName string
+	ChainName          string
+	Provider           provider.Provider
+	TLSConfig          *tls.Config
 }
 
 //RegisterOptions is options when you register a schema to chassis

--- a/core/server/server_manager.go
+++ b/core/server/server_manager.go
@@ -132,9 +132,10 @@ func initialServer(providerMap map[string]string, p model.Protocol, name string)
 
 	var s ProtocolServer
 	o := Options{
-		Address:   p.Listen,
-		ChainName: chainName,
-		TLSConfig: tlsConfig,
+		Address:            p.Listen,
+		ProtocolServerName: name,
+		ChainName:          chainName,
+		TLSConfig:          tlsConfig,
 	}
 	s = f(o)
 	servers[name] = s

--- a/server/restful/restful_server.go
+++ b/server/restful/restful_server.go
@@ -256,7 +256,7 @@ func (r *restfulServer) Start() error {
 		return fmt.Errorf("failed to start listener: %s", err.Error())
 	}
 
-	registry.InstanceEndpoints[Name] = net.JoinHostPort(lIP, lPort)
+	registry.InstanceEndpoints[config.ProtocolServerName] = net.JoinHostPort(lIP, lPort)
 
 	go func() {
 		err = r.server.Serve(l)
@@ -267,7 +267,7 @@ func (r *restfulServer) Start() error {
 
 	}()
 
-	lager.Logger.Infof("Restful server listening on: %s", registry.InstanceEndpoints[Name])
+	lager.Logger.Infof("Restful server listening on: %s", registry.InstanceEndpoints[config.ProtocolServerName])
 	return nil
 }
 


### PR DESCRIPTION
if i register 
    rest:
      listenAddress: 127.0.0.1:30101
    rest-admin:
      listenAddress: 127.0.0.1:30102

will only rest://127.0.0.1:30102 on sc.


if find it on mesher.
if i register by mesher
    rest:
      listenAddress: 127.0.0.1:30101
    rest-admin:
      listenAddress: *.*.*.*:30102
on sc.
  rest://127.0.0.1:30102
  rest-admin://*.*.*.*:30102

rest protocol port will change