### PR TITLE
.\lager_event_listener.go文件 event.value断言类型panic修复

### DIFF
--- a/eventlistener/lager_event_listener.go
+++ b/eventlistener/lager_event_listener.go
@@ -37,7 +37,7 @@ func (e *LagerEventListener) Event(event *core.Event) {
 
 	Value, ok := event.Value.(string)
 	if !ok {
-		openlogging.GetLogger().Errorf("event.Value Assertion err:%s", event.event.Value)
+		openlogging.GetLogger().Errorf("event.Value Assertion err:%s", event.Value)
 		return
 	}
 

--- a/eventlistener/lager_event_listener.go
+++ b/eventlistener/lager_event_listener.go
@@ -23,15 +23,26 @@ type LagerEventListener struct {
 
 //Event is a method for Lager event listening
 func (e *LagerEventListener) Event(event *core.Event) {
+	defer func() {
+		if err := recover(); err != nil {
+			lager.Logger.Error(err)
+		}
+	}()
 	logger := openlogging.GetLogger()
 	logger.Debugf("Get lager event, key: %s, type: %s", event.Key, event.EventType)
 	l, ok := logger.(lager.Logger)
 	if !ok {
 		return
 	}
-
 	var lagerLogLevel lager.LogLevel
-	switch strings.ToUpper(event.Value.(string)) {
+	Value,ok:=event.Value.(string)
+	if !ok{
+		fmt.Printf("event.Value Assertion err: %s", event.Value)
+		lager.Logger.Error("event.value assertion err")
+		return
+	}
+
+	switch strings.ToUpper(Value) {
 	case log.DEBUG:
 		lagerLogLevel = lager.DEBUG
 	case log.INFO:

--- a/eventlistener/lager_event_listener.go
+++ b/eventlistener/lager_event_listener.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"github.com/go-chassis/go-archaius/core"
 	"github.com/go-chassis/go-chassis/core/common"
-	"github.com/go-chassis/paas-lager"
 	"github.com/go-chassis/paas-lager/third_party/forked/cloudfoundry/lager"
 	"github.com/go-mesh/openlogging"
 	"strings"
@@ -35,8 +34,8 @@ func (e *LagerEventListener) Event(event *core.Event) {
 		return
 	}
 	var lagerLogLevel lager.LogLevel
-	Value,ok:=event.Value.(string)
-	if !ok{
+	Value, ok := event.Value.(string)
+	if !ok {
 		fmt.Printf("event.Value Assertion err: %s", event.Value)
 		lager.Logger.Error("event.value assertion err")
 		return

--- a/eventlistener/lager_event_listener.go
+++ b/eventlistener/lager_event_listener.go
@@ -37,8 +37,7 @@ func (e *LagerEventListener) Event(event *core.Event) {
 
 	Value, ok := event.Value.(string)
 	if !ok {
-		fmt.Printf("event.Value Assertion err: %s", event.Value)
-		openlogging.GetLogger().Error("event.Value Assertion err")
+		openlogging.GetLogger().Errorf("event.Value Assertion err:%s", event.event.Value)
 		return
 	}
 

--- a/eventlistener/lager_event_listener.go
+++ b/eventlistener/lager_event_listener.go
@@ -34,6 +34,7 @@ func (e *LagerEventListener) Event(event *core.Event) {
 		return
 	}
 	var lagerLogLevel lager.LogLevel
+
 	Value, ok := event.Value.(string)
 	if !ok {
 		fmt.Printf("event.Value Assertion err: %s", event.Value)

--- a/eventlistener/lager_event_listener.go
+++ b/eventlistener/lager_event_listener.go
@@ -6,6 +6,7 @@ import (
 	"github.com/go-chassis/go-chassis/core/common"
 	"github.com/go-chassis/paas-lager/third_party/forked/cloudfoundry/lager"
 	"github.com/go-mesh/openlogging"
+	"github.com/go-chassis/paas-lager"
 	"strings"
 )
 
@@ -37,7 +38,8 @@ func (e *LagerEventListener) Event(event *core.Event) {
 
 	Value, ok := event.Value.(string)
 	if !ok {
-		openlogging.GetLogger().Errorf("event.Value Assertion err:%s", event.Value)
+		openlogging.GetLogger().Errorf("event.Value Assertion err:%s", event.
+			Value)
 		return
 	}
 

--- a/eventlistener/lager_event_listener.go
+++ b/eventlistener/lager_event_listener.go
@@ -24,7 +24,7 @@ type LagerEventListener struct {
 func (e *LagerEventListener) Event(event *core.Event) {
 	defer func() {
 		if err := recover(); err != nil {
-			lager.Logger.Error(err)
+			openlogging.GetLogger().Errorf("%s", err)
 		}
 	}()
 	logger := openlogging.GetLogger()
@@ -38,7 +38,7 @@ func (e *LagerEventListener) Event(event *core.Event) {
 	Value, ok := event.Value.(string)
 	if !ok {
 		fmt.Printf("event.Value Assertion err: %s", event.Value)
-		lager.Logger.Error("event.value assertion err")
+		openlogging.GetLogger().Error("event.Value Assertion err")
 		return
 	}
 


### PR DESCRIPTION
event.value.(string)如果为int类型，框架直接painc,并且没有recover()。
此次修改加上recover和断言错误处理。