### PR TITLE
Bugfix: go-chassis will return 406 if `Produces` not been defined but `Accept` exist in request headers

### DIFF
--- a/server/restful/restful_server.go
+++ b/server/restful/restful_server.go
@@ -208,9 +208,13 @@ func (r *restfulServer) register2GoRestful(routeSpec Route, handler restful.Rout
 
 	if len(routeSpec.Consumes) > 0 {
 		rb = rb.Consumes(routeSpec.Consumes...)
+	} else {
+		rb = rb.Consumes("*/*")
 	}
 	if len(routeSpec.Produces) > 0 {
 		rb = rb.Produces(routeSpec.Produces...)
+	} else {
+		rb = rb.Produces("*/*")
 	}
 	r.ws.Route(rb.To(handler).Doc(routeSpec.FuncDesc).Operation(routeSpec.ResourceFuncName))
 


### PR DESCRIPTION
To fix issue #659 