### PR TITLE
Bugfix: Update go.mod to fix duplicate atomic requirement packages path issue

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,26 +8,26 @@ require (
 	github.com/go-chassis/go-chassis-config v0.9.0
 	github.com/go-chassis/go-restful-swagger20 v1.0.1
 	github.com/go-chassis/paas-lager v1.0.2-0.20190328010332-cf506050ddb2
-	github.com/go-logfmt/logfmt v0.4.0 // indirect
 	github.com/go-mesh/openlogging v1.0.0
 	github.com/golang/protobuf v1.2.0
-	github.com/golang/snappy v0.0.1 // indirect
 	github.com/gopherjs/gopherjs v0.0.0-20181103185306-d547d1d9531e // indirect
 	github.com/gorilla/websocket v1.4.0
 	github.com/hashicorp/go-version v1.0.0
+	github.com/onsi/ginkgo v1.8.0 // indirect
+	github.com/onsi/gomega v1.5.0 // indirect
 	github.com/opentracing/opentracing-go v1.0.2
 	github.com/patrickmn/go-cache v2.1.0+incompatible
-	github.com/pierrec/lz4 v2.0.5+incompatible // indirect
 	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v0.9.1
 	github.com/prometheus/client_model v0.0.0-20190115171406-56726106282f // indirect
 	github.com/prometheus/common v0.2.0
 	github.com/prometheus/procfs v0.0.0-20190117184657-bf6a532e95b1 // indirect
-	github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a // indirect
 	github.com/smartystreets/assertions v0.0.0-20190116191733-b6c0e53d7304 // indirect
 	github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a
 	github.com/stretchr/testify v1.3.0
-	go.uber.org/ratelimit v0.0.0-20180316092928-c15da0234277
+	go.uber.org/atomic v1.4.0 // indirect
+	go.uber.org/ratelimit v0.1.0
+	gopkg.in/go-playground/assert.v1 v1.2.1 // indirect
 	gopkg.in/yaml.v2 v2.2.1
 )
 


### PR DESCRIPTION
The default `go.mod` introduces a couple of `atomic` go modules with different paths, see:
![image](https://user-images.githubusercontent.com/46245845/62095235-59154600-b2b2-11e9-92b5-f5c048820a53.png)

The root cause is `ratelimit` uses incorrect `atomic` module path in its test files, an issue was raised and solved recently, find it here: https://github.com/uber-go/ratelimit/issues/18

This PR it going to fix duplicate atomic requirement packages path issue. 

FYI: the differences between the old and new imported version of `ratelimit`:
https://github.com/uber-go/ratelimit/compare/c15da02342779cb6dc027fc95ee2277787698f36...cd1f0abeddc3fe992a7be8d533332897936efbc0