### PR TITLE
feat:1, group route;2, direct register hanler func;3, refactor code u…

### DIFF
--- a/server/restful/restful_server.go
+++ b/server/restful/restful_server.go
@@ -106,20 +106,20 @@ func (r *restfulServer) Register(schema interface{}, options ...server.RegisterO
 	if err != nil {
 		return "", err
 	}
-	schemaType := reflect.TypeOf(schema)
-	schemaValue := reflect.ValueOf(schema)
+
 	var schemaName string
-	tokens := strings.Split(schemaType.String(), ".")
+	tokens := strings.Split(reflect.TypeOf(schema).String(), ".")
 	if len(tokens) >= 1 {
 		schemaName = tokens[len(tokens)-1]
 	}
 	openlogging.GetLogger().Infof("schema registered is [%s]", schemaName)
-	for _, route := range routes {
-		handler, err := WrapHandlerChain(route, schemaType, schemaValue, schemaName, r.opts)
+	for k, _ := range routes {
+		GroupRoutePath(&routes[k], schema)
+		handler, err := WrapHandlerChain(&routes[k], schema, schemaName, r.opts)
 		if err != nil {
 			return "", err
 		}
-		if err := Register2GoRestful(route, r.ws, handler); err != nil {
+		if err := Register2GoRestful(routes[k], r.ws, handler); err != nil {
 			return "", err
 		}
 	}

--- a/server/restful/restfultest/restfultest.go
+++ b/server/restful/restfultest/restfultest.go
@@ -19,7 +19,6 @@ package restfultest
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"reflect"
 	"strings"
@@ -47,22 +46,18 @@ func New(schema interface{}, chain *handler.Chain) (*Container, error) {
 	if err != nil {
 		panic(err)
 	}
-	schemaType := reflect.TypeOf(schema)
-	schemaValue := reflect.ValueOf(schema)
+
 	var schemaName string
-	tokens := strings.Split(schemaType.String(), ".")
+	tokens := strings.Split(reflect.TypeOf(schema).String(), ".")
 	if len(tokens) >= 1 {
 		schemaName = tokens[len(tokens)-1]
 	}
-	for _, route := range routes {
-		method, exist := schemaType.MethodByName(route.ResourceFuncName)
-		if !exist {
-			openlogging.GetLogger().Errorf("router func can not find: %s", route.ResourceFuncName)
-			return nil, fmt.Errorf("router func can not find: %s", route.ResourceFuncName)
-		}
+	for k, _ := range routes {
+		chassisRestful.GroupRoutePath(&routes[k], schema)
+		handleFunc, err := chassisRestful.BuildRouteHandler(&routes[k], schema)
 
 		handler := func(req *restful.Request, rep *restful.Response) {
-			inv, err := chassisRestful.HTTPRequest2Invocation(req, schemaName, method.Name)
+			inv, err := chassisRestful.HTTPRequest2Invocation(req, schemaName, routes[k].ResourceFuncName)
 			if err != nil {
 				openlogging.Error("transfer http request to invocation failed", openlogging.WithTags(openlogging.Tags{
 					"err": err.Error(),
@@ -87,10 +82,10 @@ func New(schema interface{}, chain *handler.Chain) (*Container, error) {
 			bs.Req = req
 			bs.Resp = rep
 
-			method.Func.Call([]reflect.Value{schemaValue, reflect.ValueOf(bs)})
+			handleFunc(bs)
 		}
 
-		if err = chassisRestful.Register2GoRestful(route, c.ws, handler); err != nil {
+		if err = chassisRestful.Register2GoRestful(routes[k], c.ws, handler); err != nil {
 			return nil, err
 		}
 	}

--- a/server/restful/restfultest/restfultest_test.go
+++ b/server/restful/restfultest/restfultest_test.go
@@ -34,6 +34,10 @@ import (
 type DummyResource struct {
 }
 
+func (r *DummyResource) GroupPath() string{
+	return "/demo"
+}
+
 func (r *DummyResource) Sayhello(b *restful.Context) {
 	id := b.ReadPathParameter("userid")
 	b.Write([]byte(id))
@@ -43,6 +47,8 @@ func (r *DummyResource) Sayhello(b *restful.Context) {
 func (r *DummyResource) URLPatterns() []restful.Route {
 	return []restful.Route{
 		{Method: http.MethodGet, Path: "/sayhello/{userid}", ResourceFuncName: "Sayhello",
+			Returns: []*restful.Returns{{Code: 200}}},
+		{Method: http.MethodGet, Path: "/sayhello2/{userid}", ResourceFunc:r.Sayhello,
 			Returns: []*restful.Returns{{Code: 200}}},
 	}
 }
@@ -64,7 +70,7 @@ func newFakeHandler() handler.Handler {
 }
 
 func TestNew(t *testing.T) {
-	r, _ := http.NewRequest("GET", "/sayhello/some_user", nil)
+	r, _ := http.NewRequest("GET", "/demo/sayhello/some_user", nil)
 	c, err := restfultest.New(&DummyResource{}, nil)
 	assert.NoError(t, err)
 	resp := httptest.NewRecorder()
@@ -72,6 +78,12 @@ func TestNew(t *testing.T) {
 	body, err := ioutil.ReadAll(resp.Body)
 	assert.NoError(t, err)
 	assert.Equal(t, "some_user", string(body))
+
+	r, _ = http.NewRequest("GET", "/demo/sayhello2/another_user", nil)
+	c.ServeHTTP(resp, r)
+	body, err = ioutil.ReadAll(resp.Body)
+	assert.NoError(t, err)
+	assert.Equal(t, "another_user", string(body))
 }
 
 func TestNewWithChain(t *testing.T) {

--- a/server/restful/router_test.go
+++ b/server/restful/router_test.go
@@ -1,32 +1,82 @@
-package restful_test
+package restful
 
 import (
-	"github.com/go-chassis/go-chassis/server/restful"
+	"context"
 	"github.com/stretchr/testify/assert"
 	"net/http"
 	"testing"
 )
 
 func TestGetRouteSpecs(t *testing.T) {
-	_, err := restful.GetRouteSpecs(WrongSchema{})
+	_, err := GetRouteSpecs(WrongSchema{})
 	assert.Error(t, err)
-	_, err = restful.GetRouteSpecs(&WrongSchema{})
+	_, err = GetRouteSpecs(&WrongSchema{})
 	assert.Error(t, err)
-	_, err = restful.GetRouteSpecs(&WrongSchema2{})
+	_, err = GetRouteSpecs(&WrongSchema2{})
 	assert.Error(t, err)
+}
+
+func TestGetRouteGroup(t *testing.T) {
+	gn := GetRouteGroup(&GroupSchema{})
+	assert.Equal(t, "HelloGroup", gn)
+}
+
+func TestGroupRoutePath(t *testing.T) {
+	r := &Route{Path:"/SubRoute"}
+	GroupRoutePath(r, &GroupSchema{})
+	assert.Equal(t, "HelloGroup/SubRoute", r.Path)
+}
+
+func TestGetFunctionName(t *testing.T) {
+	ws := &WrongSchema{}
+	name := getFunctionName(ws.URLPatterns2)
+	assert.Equal(t, "URLPatterns2", name)
+	name = getFunctionName(TestGetRouteGroup)
+	assert.Equal(t, "TestGetRouteGroup", name)
+}
+
+func TestBuildRouteHandler(t *testing.T) {
+	schma := &FuncNameSchema{}
+	ctx := &Context{ Ctx: context.TODO() }
+
+	// FuncName
+	route := Route{Path:"/FuncName", ResourceFuncName:"Hello"}
+	f, err := BuildRouteHandler(&route, schma)
+	assert.NoError(t, err)
+	assert.Equal(t, "Hello", route.ResourceFuncName)
+	f(ctx)
+	assert.Equal(t, "World", ctx.Ctx.Value("Hello"))
+
+	// Func
+	ctx = &Context{ Ctx: context.TODO() }
+	route = Route{Path:"/Func", ResourceFunc:schma.Hello}
+	f, err = BuildRouteHandler(&route, schma)
+	assert.NoError(t, err)
+	assert.Equal(t, "Hello", route.ResourceFuncName)
+	f(ctx)
+	assert.Equal(t, "World", ctx.Ctx.Value("Hello"))
+
+	// Both
+	ctx = &Context{ Ctx: context.TODO() }
+	route = Route{Path:"/BothFuncAndName", ResourceFunc: schma.Hello,ResourceFuncName:"World"}
+	f, err = BuildRouteHandler(&route, schma)
+	assert.NoError(t, err)
+	assert.Equal(t, "Hello", route.ResourceFuncName)
+	f(ctx)
+	assert.Equal(t, "World", ctx.Ctx.Value("Hello"))
 }
 
 type WrongSchema struct {
 }
 
-func (r *WrongSchema) Put(b *restful.Context) {
+func (r *WrongSchema) Put(b *Context) {
 }
 
 //URLPatterns helps to respond for corresponding API calls
-func (r *WrongSchema) URLPatterns2() []restful.Route {
-	return []restful.Route{
+func (r *WrongSchema) URLPatterns2() []Route {
+	return []Route{
 		{Method: http.MethodGet, Path: "/", ResourceFuncName: "Put",
-			Returns: []*restful.Returns{{Code: 200}}},
+			Returns: []*Returns{{Code: 200}}},
 	}
 }
 
@@ -36,3 +86,25 @@ type WrongSchema2 struct {
 //URLPatterns helps to respond for corresponding API calls
 func (r *WrongSchema2) URLPatterns() {
 }
+
+type GroupSchema struct {
+}
+
+func (g *GroupSchema) GroupPath() string {
+	return "HelloGroup"
+}
+
+type FuncNameSchema struct {
+}
+
+func(s *FuncNameSchema) URLPatterns() []Route {
+	return []Route{
+		{ Method: http.MethodGet, Path: "/HelloPath", ResourceFunc:s.Hello, ResourceFuncName: "Hello" },
+	}
+}
+
+func(s *FuncNameSchema) Hello(ctx *Context) {
+	ctx.Ctx = context.WithValue(ctx.Ctx,"Hello", "World")
+}
+
+


### PR DESCRIPTION
feat:
- group route: now we can emit repeatable pre-path by implement GroupPath();
```
func (r *DummyResource) GroupPath() string{
	return "/demo"
}
```
- direct register hanler function;
```
func (r *DummyResource) URLPatterns() []restful.Route {
	return []restful.Route{
		{Method: http.MethodGet, Path: "/sayhello/{userid}", ResourceFuncName: "Sayhello",
			Returns: []*restful.Returns{{Code: 200}}},
                // we can register handler function to optimize performance
		{Method: http.MethodGet, Path: "/sayhello2/{userid}", ResourceFunc:r.Sayhello,
			Returns: []*restful.Returns{{Code: 200}}},
	}
}
```
- refactor code using interface instead reflect;