### PR TITLE
some feats as description

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ sudo pip install sphinx_rtd_theme
 
 In windows
 ```shell
+pip install recommonmark
 cd docs
 make.bat html
 ```

--- a/docs/dev-guides.rst
+++ b/docs/dev-guides.rst
@@ -12,3 +12,4 @@ Development guides
     dev-guides/how-to-write-cipher
     dev-guides/how-to-extend-protocol
     dev-guides/bootstrap
+    dev-guides/restful

--- a/docs/dev-guides/restful.md
+++ b/docs/dev-guides/restful.md
@@ -1,0 +1,87 @@
+# Restful Development
+
+## 概述
+go chassis 提供了Restful风格的http服务，基于 [go-restful](https://github.com/emicklei/go-restful)，使用方法请参阅下面的节点。
+
+> yaml的设置请参考 [Get started](../getstarted/writing-rest.html)
+
+## 路由注册
+### 通过路由函数
+
+```go
+type DummyResource struct {
+}
+
+func (r *DummyResource) Sayhello(b *restful.Context) {
+	id := b.ReadPathParameter("userid")
+	b.Write([]byte(id))
+}
+
+//URLPatterns helps to respond for corresponding API calls
+func (r *DummyResource) URLPatterns() []restful.Route {
+	return []restful.Route{
+		{Method: http.MethodGet, Path: "/sayhello/{userid}", ResourceFunc: r.Sayhello,
+			Returns: []*restful.Returns{{Code: 200}}},
+	}
+}
+```
+
+### 通过函数名称（不推荐）
+
+这是兼容旧版本的一种方式，由于实现使用了reflect，性能会有所损耗
+
+```go
+type DummyResource struct {
+}
+
+func (r *DummyResource) GroupPath() string {
+	return "/demo"
+}
+
+func (r *DummyResource) Sayhello(b *restful.Context) {
+	id := b.ReadPathParameter("userid")
+	b.Write([]byte(id))
+}
+
+//URLPatterns helps to respond for corresponding API calls
+func (r *DummyResource) URLPatterns() []restful.Route {
+	return []restful.Route{
+		{Method: http.MethodGet, Path: "/sayhello/{userid}", ResourceFuncName: "Sayhello",
+			Returns: []*restful.Returns{{Code: 200}}},
+	}
+}
+```
+## 路由分组
+
+相同资源的多个路由可能会具备同样的路由前缀，这时候你可以使用路由分组来避免重复的路由前缀
+
+```go
+type DummyResource struct {
+}
+
+//GroupPath returns group path will auto 
+func (r *DummyResource) GroupPath() string {
+	return "/demo"
+}
+
+func (r *DummyResource) Sayhello(b *restful.Context) {
+	id := b.ReadPathParameter("userid")
+	b.Write([]byte(id))
+}
+
+func (r *DummyResource) Panic(b *restful.Context) {
+	panic("panic msg")
+}
+
+//URLPatterns helps to respond for corresponding API calls
+func (r *DummyResource) URLPatterns() []restful.Route {
+	return []restful.Route{ 
+		// will register path:/demo/sayhello
+		{Method: http.MethodGet, Path: "/sayhello", ResourceFunc: r.Sayhello,
+		    Returns: []*restful.Returns{{Code: 200}}},
+        // will register path:/demo/sayhelloagain
+        {Method: http.MethodGet, Path: "/sayhelloagain", ResourceFunc: r.Sayhello,
+            Returns: []*restful.Returns{{Code: 200}}},
+	}
+}
+```

--- a/docs/dev-guides/restful.md
+++ b/docs/dev-guides/restful.md
@@ -26,31 +26,6 @@ func (r *DummyResource) URLPatterns() []restful.Route {
 }
 ```
 
-### 通过函数名称（不推荐）
-
-这是兼容旧版本的一种方式，由于实现使用了reflect，性能会有所损耗
-
-```go
-type DummyResource struct {
-}
-
-func (r *DummyResource) GroupPath() string {
-	return "/demo"
-}
-
-func (r *DummyResource) Sayhello(b *restful.Context) {
-	id := b.ReadPathParameter("userid")
-	b.Write([]byte(id))
-}
-
-//URLPatterns helps to respond for corresponding API calls
-func (r *DummyResource) URLPatterns() []restful.Route {
-	return []restful.Route{
-		{Method: http.MethodGet, Path: "/sayhello/{userid}", ResourceFuncName: "Sayhello",
-			Returns: []*restful.Returns{{Code: 200}}},
-	}
-}
-```
 ## 路由分组
 
 相同资源的多个路由可能会具备同样的路由前缀，这时候你可以使用路由分组来避免重复的路由前缀

--- a/server/restful/restful_server.go
+++ b/server/restful/restful_server.go
@@ -106,20 +106,20 @@ func (r *restfulServer) Register(schema interface{}, options ...server.RegisterO
 	if err != nil {
 		return "", err
 	}
-	schemaType := reflect.TypeOf(schema)
-	schemaValue := reflect.ValueOf(schema)
+
 	var schemaName string
-	tokens := strings.Split(schemaType.String(), ".")
+	tokens := strings.Split(reflect.TypeOf(schema).String(), ".")
 	if len(tokens) >= 1 {
 		schemaName = tokens[len(tokens)-1]
 	}
 	openlogging.GetLogger().Infof("schema registered is [%s]", schemaName)
-	for _, route := range routes {
-		handler, err := WrapHandlerChain(route, schemaType, schemaValue, schemaName, r.opts)
+	for k := range routes {
+		GroupRoutePath(&routes[k], schema)
+		handler, err := WrapHandlerChain(&routes[k], schema, schemaName, r.opts)
 		if err != nil {
 			return "", err
 		}
-		if err := Register2GoRestful(route, r.ws, handler); err != nil {
+		if err := Register2GoRestful(routes[k], r.ws, handler); err != nil {
 			return "", err
 		}
 	}

--- a/server/restful/restfultest/restfultest.go
+++ b/server/restful/restfultest/restfultest.go
@@ -47,22 +47,26 @@ func New(schema interface{}, chain *handler.Chain) (*Container, error) {
 	if err != nil {
 		panic(err)
 	}
-	schemaType := reflect.TypeOf(schema)
-	schemaValue := reflect.ValueOf(schema)
+
 	var schemaName string
-	tokens := strings.Split(schemaType.String(), ".")
+	tokens := strings.Split(reflect.TypeOf(schema).String(), ".")
 	if len(tokens) >= 1 {
 		schemaName = tokens[len(tokens)-1]
 	}
-	for _, route := range routes {
-		method, exist := schemaType.MethodByName(route.ResourceFuncName)
-		if !exist {
-			openlogging.GetLogger().Errorf("router func can not find: %s", route.ResourceFuncName)
-			return nil, fmt.Errorf("router func can not find: %s", route.ResourceFuncName)
-		}
+	for k := range routes {
+		chassisRestful.GroupRoutePath(&routes[k], schema)
+		handleFunc, err := chassisRestful.BuildRouteHandler(&routes[k], schema)
 
 		handler := func(req *restful.Request, rep *restful.Response) {
-			inv, err := chassisRestful.HTTPRequest2Invocation(req, schemaName, method.Name)
+			defer func() {
+				if r := recover(); r != nil {
+					openlogging.Error(fmt.Sprintf("handle request panic. path:%s, panic:%s", routes[k].Path, r))
+					if err := rep.WriteErrorString(http.StatusInternalServerError, "server got a panic, plz check log."); err != nil {
+						openlogging.Error("write response failed when handler panic, err:" + err.Error())
+					}
+				}
+			}()
+			inv, err := chassisRestful.HTTPRequest2Invocation(req, schemaName, routes[k].ResourceFuncName)
 			if err != nil {
 				openlogging.Error("transfer http request to invocation failed", openlogging.WithTags(openlogging.Tags{
 					"err": err.Error(),
@@ -87,10 +91,10 @@ func New(schema interface{}, chain *handler.Chain) (*Container, error) {
 			bs.Req = req
 			bs.Resp = rep
 
-			method.Func.Call([]reflect.Value{schemaValue, reflect.ValueOf(bs)})
+			handleFunc(bs)
 		}
 
-		if err = chassisRestful.Register2GoRestful(route, c.ws, handler); err != nil {
+		if err = chassisRestful.Register2GoRestful(routes[k], c.ws, handler); err != nil {
 			return nil, err
 		}
 	}

--- a/server/restful/restfultest/restfultest.go
+++ b/server/restful/restfultest/restfultest.go
@@ -19,7 +19,6 @@ package restfultest
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"reflect"
 	"strings"
@@ -60,9 +59,14 @@ func New(schema interface{}, chain *handler.Chain) (*Container, error) {
 		handler := func(req *restful.Request, rep *restful.Response) {
 			defer func() {
 				if r := recover(); r != nil {
-					openlogging.Error(fmt.Sprintf("handle request panic. path:%s, panic:%s", routes[k].Path, r))
+					openlogging.Error("handle request panic.", openlogging.WithTags(openlogging.Tags{
+						"path":  routes[k].Path,
+						"panic": r,
+					}))
 					if err := rep.WriteErrorString(http.StatusInternalServerError, "server got a panic, plz check log."); err != nil {
-						openlogging.Error("write response failed when handler panic, err:" + err.Error())
+						openlogging.Error("write response failed when handler panic,", openlogging.WithTags(openlogging.Tags{
+							"err": err.Error(),
+						}))
 					}
 				}
 			}()

--- a/server/restful/router.go
+++ b/server/restful/router.go
@@ -4,6 +4,9 @@ import (
 	"fmt"
 	"net/http"
 	"reflect"
+	"regexp"
+	"runtime"
+	"strings"
 
 	"github.com/emicklei/go-restful"
 	"github.com/go-chassis/go-chassis/core/common"
@@ -21,15 +24,16 @@ const (
 
 //Route describe http route path and swagger specifications for API
 type Route struct {
-	Method           string        //Method is one of the following: GET,PUT,POST,DELETE. required
-	Path             string        //Path contains a path pattern. required
-	ResourceFuncName string        //the func this API calls. required
-	FuncDesc         string        //tells what this route is all about. Optional.
-	Parameters       []*Parameters //Parameters is a slice of request parameters for a single endpoint Optional.
-	Returns          []*Returns    //what kind of response this API returns. Optional.
-	Read             interface{}   //Read tells what resource type will be read from the request payload. Optional.
-	Consumes         []string      //Consumes specifies that this WebService can consume one or more MIME types.
-	Produces         []string      //Produces specifies that this WebService can produce one or more MIME types.
+	Method           string             //Method is one of the following: GET,PUT,POST,DELETE. required
+	Path             string             //Path contains a path pattern. required
+	ResourceFunc     func(ctx *Context) //the func this API calls. you must set this field or ResourceFunc, if you set both, ResourceFunc will be used
+	ResourceFuncName string             //the func this API calls. you must set this field or ResourceFunc
+	FuncDesc         string             //tells what this route is all about. Optional.
+	Parameters       []*Parameters      //Parameters is a slice of request parameters for a single endpoint Optional.
+	Returns          []*Returns         //what kind of response this API returns. Optional.
+	Read             interface{}        //Read tells what resource type will be read from the request payload. Optional.
+	Consumes         []string           //Consumes specifies that this WebService can consume one or more MIME types.
+	Produces         []string           //Produces specifies that this WebService can produce one or more MIME types.
 }
 
 //Returns describe response doc
@@ -47,40 +51,53 @@ type Parameters struct {
 	Desc      string
 }
 
+//Router is to define how route the request
+type Router interface {
+	//URLPatterns returns route
+	URLPatterns() []Route
+}
+
+//RouteGroup is to define the route group name
+type RouteGroup interface {
+	//GroupPath if return non-zero-value, it would be appended to route as prefix
+	GroupPath() string
+}
+
+//GetRouteGroup is to return a router group path
+func GetRouteGroup(schema interface{}) string {
+	v, ok := schema.(RouteGroup)
+	if !ok {
+		return ""
+	}
+
+	return v.GroupPath()
+}
+
 //GetRouteSpecs is to return a rest API specification of a go struct
 func GetRouteSpecs(schema interface{}) ([]Route, error) {
-	rfValue := reflect.ValueOf(schema)
-	name := reflect.Indirect(rfValue).Type().Name()
-	urlPatternFunc := rfValue.MethodByName("URLPatterns")
-	if !urlPatternFunc.IsValid() {
-		return []Route{}, fmt.Errorf("<rest.RegisterResource> no 'URLPatterns' function in servant struct `%s`", name)
+	v, ok := schema.(Router)
+	if !ok {
+		return []Route{}, fmt.Errorf("<rest.RegisterResource> is not implemetn Router interface")
 	}
-	vals := urlPatternFunc.Call([]reflect.Value{})
-	if len(vals) <= 0 {
-		return []Route{}, fmt.Errorf("<rest.RegisterResource> call URLPatterns function failed in struct `%s`", name)
-	}
-
-	if !rfValue.CanInterface() {
-		return []Route{}, fmt.Errorf("<rest.RegisterResource> result of 'URLPatterns' function not interface type in servant struct `%s`", name)
-	}
-
-	if routes, ok := vals[0].Interface().([]Route); ok {
-		return routes, nil
-	}
-	return []Route{}, fmt.Errorf("<rest.RegisterResource> result of 'URLPatterns' function not []*Route type in servant struct `%s`", name)
+	return v.URLPatterns(), nil
 }
 
 //WrapHandlerChain wrap business handler with handler chain
-func WrapHandlerChain(route Route, schemaType reflect.Type, schemaValue reflect.Value, schemaName string,
-	opts server.Options) (restful.RouteFunction, error) {
-	openlogging.GetLogger().Infof("add route path: [%s] method: [%s] func: [%s]. ", route.Path, route.Method, route.ResourceFuncName)
-	method, exist := schemaType.MethodByName(route.ResourceFuncName)
-	if !exist {
-		openlogging.GetLogger().Errorf("router func can not find: %s", route.ResourceFuncName)
-		return nil, fmt.Errorf("router func can not find: %s", route.ResourceFuncName)
+func WrapHandlerChain(route *Route, schema interface{}, schemaName string, opts server.Options) (restful.RouteFunction, error) {
+	handleFunc, err := BuildRouteHandler(route, schema)
+	if err != nil {
+		return nil, err
 	}
+	restHandler := func(req *restful.Request, rep *restful.Response) {
+		defer func() {
+			if r := recover(); r != nil {
+				openlogging.Error(fmt.Sprintf("handle request panic. path:%s, panic:%s", route.Path, r))
+				if err := rep.WriteErrorString(http.StatusInternalServerError, "server got a panic, plz check log."); err != nil {
+					openlogging.Error("write response failed when handler panic, err:" + err.Error())
+				}
+			}
+		}()
 
-	handler := func(req *restful.Request, rep *restful.Response) {
 		c, err := handler.GetChain(common.Provider, opts.ChainName)
 		if err != nil {
 			openlogging.GetLogger().Errorf("handler chain init err [%s]", err.Error())
@@ -88,7 +105,7 @@ func WrapHandlerChain(route Route, schemaType reflect.Type, schemaValue reflect.
 			rep.WriteErrorString(http.StatusInternalServerError, err.Error())
 			return
 		}
-		inv, err := HTTPRequest2Invocation(req, schemaName, method.Name)
+		inv, err := HTTPRequest2Invocation(req, schemaName, route.ResourceFuncName)
 		if err != nil {
 			openlogging.GetLogger().Errorf("transfer http request to invocation failed, err [%s]", err.Error())
 			return
@@ -111,7 +128,9 @@ func WrapHandlerChain(route Route, schemaType reflect.Type, schemaValue reflect.
 			if opts.BodyLimit > 0 {
 				bs.Req.Request.Body = http.MaxBytesReader(bs.Resp, bs.Req.Request.Body, opts.BodyLimit)
 			}
-			method.Func.Call([]reflect.Value{schemaValue, reflect.ValueOf(bs)})
+
+			// call real route func
+			handleFunc(bs)
 
 			if bs.Resp.StatusCode() >= http.StatusBadRequest {
 				return fmt.Errorf("get err from http handle, get status: %d", bs.Resp.StatusCode())
@@ -121,5 +140,45 @@ func WrapHandlerChain(route Route, schemaType reflect.Type, schemaValue reflect.
 
 	}
 
-	return handler, nil
+	openlogging.GetLogger().Infof("add route path: [%s] method: [%s] func: [%s]. ", route.Path, route.Method, route.ResourceFuncName)
+	return restHandler, nil
+}
+
+// GroupRoutePath add group route path to route
+func GroupRoutePath(route *Route, schema interface{}) {
+	groupPath := GetRouteGroup(schema)
+	if groupPath != "" {
+		route.Path = groupPath + route.Path
+	}
+}
+
+//BuildRouteHandler build handler func from ResourceFunc or ResourceFuncName
+func BuildRouteHandler(route *Route, schema interface{}) (func(ctx *Context), error) {
+	if route.ResourceFunc != nil {
+		route.ResourceFuncName = getFunctionName(route.ResourceFunc)
+		return func(ctx *Context) {
+			route.ResourceFunc(ctx)
+		}, nil
+	}
+
+	method, exist := reflect.TypeOf(schema).MethodByName(route.ResourceFuncName)
+	if !exist {
+		openlogging.GetLogger().Errorf("router func can not find: %s", route.ResourceFuncName)
+		return nil, fmt.Errorf("router func can not find: %s", route.ResourceFuncName)
+	}
+
+	return func(ctx *Context) {
+		method.Func.Call([]reflect.Value{reflect.ValueOf(schema), reflect.ValueOf(ctx)})
+	}, nil
+}
+
+//getFunctionName get method name from func
+func getFunctionName(i interface{}) string {
+	metaName := runtime.FuncForPC(reflect.ValueOf(i).Pointer()).Name()
+	metaNameArr := strings.Split(metaName, ".")
+	funcName := metaNameArr[len(metaNameArr)-1]
+
+	// replace suffix "-fm" if function is bounded to struct
+	reg := regexp.MustCompile("-fm$")
+	return reg.ReplaceAllString(funcName, "")
 }

--- a/server/restful/router.go
+++ b/server/restful/router.go
@@ -168,7 +168,10 @@ func GroupRoutePath(route *Route, schema interface{}) {
 //BuildRouteHandler build handler func from ResourceFunc or ResourceFuncName
 func BuildRouteHandler(route *Route, schema interface{}) (func(ctx *Context), error) {
 	if route.ResourceFunc != nil {
-		route.ResourceFuncName = getFunctionName(route.ResourceFunc)
+		if route.ResourceFuncName == "" {
+			route.ResourceFuncName = getFunctionName(route.ResourceFunc)
+		}
+
 		return func(ctx *Context) {
 			route.ResourceFunc(ctx)
 		}, nil

--- a/server/restful/router_test.go
+++ b/server/restful/router_test.go
@@ -61,7 +61,7 @@ func TestBuildRouteHandler(t *testing.T) {
 	route = Route{Path: "/BothFuncAndName", ResourceFunc: schma.Hello, ResourceFuncName: "World"}
 	f, err = BuildRouteHandler(&route, schma)
 	assert.NoError(t, err)
-	assert.Equal(t, "Hello", route.ResourceFuncName)
+	assert.Equal(t, "World", route.ResourceFuncName)
 	f(ctx)
 	assert.Equal(t, "World", ctx.Ctx.Value("Hello"))
 }

--- a/server/restful/router_test.go
+++ b/server/restful/router_test.go
@@ -1,32 +1,82 @@
-package restful_test
+package restful
 
 import (
-	"github.com/go-chassis/go-chassis/server/restful"
+	"context"
 	"github.com/stretchr/testify/assert"
 	"net/http"
 	"testing"
 )
 
 func TestGetRouteSpecs(t *testing.T) {
-	_, err := restful.GetRouteSpecs(WrongSchema{})
+	_, err := GetRouteSpecs(WrongSchema{})
 	assert.Error(t, err)
-	_, err = restful.GetRouteSpecs(&WrongSchema{})
+	_, err = GetRouteSpecs(&WrongSchema{})
 	assert.Error(t, err)
-	_, err = restful.GetRouteSpecs(&WrongSchema2{})
+	_, err = GetRouteSpecs(&WrongSchema2{})
 	assert.Error(t, err)
+}
+
+func TestGetRouteGroup(t *testing.T) {
+	gn := GetRouteGroup(&GroupSchema{})
+	assert.Equal(t, "HelloGroup", gn)
+}
+
+func TestGroupRoutePath(t *testing.T) {
+	r := &Route{Path: "/SubRoute"}
+	GroupRoutePath(r, &GroupSchema{})
+	assert.Equal(t, "HelloGroup/SubRoute", r.Path)
+}
+
+func TestGetFunctionName(t *testing.T) {
+	ws := &WrongSchema{}
+	name := getFunctionName(ws.URLPatterns2)
+	assert.Equal(t, "URLPatterns2", name)
+	name = getFunctionName(TestGetRouteGroup)
+	assert.Equal(t, "TestGetRouteGroup", name)
+}
+
+func TestBuildRouteHandler(t *testing.T) {
+	schma := &FuncNameSchema{}
+	ctx := &Context{Ctx: context.TODO()}
+
+	// FuncName
+	route := Route{Path: "/FuncName", ResourceFuncName: "Hello"}
+	f, err := BuildRouteHandler(&route, schma)
+	assert.NoError(t, err)
+	assert.Equal(t, "Hello", route.ResourceFuncName)
+	f(ctx)
+	assert.Equal(t, "World", ctx.Ctx.Value("Hello"))
+
+	// Func
+	ctx = &Context{Ctx: context.TODO()}
+	route = Route{Path: "/Func", ResourceFunc: schma.Hello}
+	f, err = BuildRouteHandler(&route, schma)
+	assert.NoError(t, err)
+	assert.Equal(t, "Hello", route.ResourceFuncName)
+	f(ctx)
+	assert.Equal(t, "World", ctx.Ctx.Value("Hello"))
+
+	// Both
+	ctx = &Context{Ctx: context.TODO()}
+	route = Route{Path: "/BothFuncAndName", ResourceFunc: schma.Hello, ResourceFuncName: "World"}
+	f, err = BuildRouteHandler(&route, schma)
+	assert.NoError(t, err)
+	assert.Equal(t, "Hello", route.ResourceFuncName)
+	f(ctx)
+	assert.Equal(t, "World", ctx.Ctx.Value("Hello"))
 }
 
 type WrongSchema struct {
 }
 
-func (r *WrongSchema) Put(b *restful.Context) {
+func (r *WrongSchema) Put(b *Context) {
 }
 
 //URLPatterns helps to respond for corresponding API calls
-func (r *WrongSchema) URLPatterns2() []restful.Route {
-	return []restful.Route{
+func (r *WrongSchema) URLPatterns2() []Route {
+	return []Route{
 		{Method: http.MethodGet, Path: "/", ResourceFuncName: "Put",
-			Returns: []*restful.Returns{{Code: 200}}},
+			Returns: []*Returns{{Code: 200}}},
 	}
 }
 
@@ -35,4 +85,24 @@ type WrongSchema2 struct {
 
 //URLPatterns helps to respond for corresponding API calls
 func (r *WrongSchema2) URLPatterns() {
+}
+
+type GroupSchema struct {
+}
+
+func (g *GroupSchema) GroupPath() string {
+	return "HelloGroup"
+}
+
+type FuncNameSchema struct {
+}
+
+func (s *FuncNameSchema) URLPatterns() []Route {
+	return []Route{
+		{Method: http.MethodGet, Path: "/HelloPath", ResourceFunc: s.Hello, ResourceFuncName: "Hello"},
+	}
+}
+
+func (s *FuncNameSchema) Hello(ctx *Context) {
+	ctx.Ctx = context.WithValue(ctx.Ctx, "Hello", "World")
 }


### PR DESCRIPTION
feat:
- group route: now we can emit repeatable pre-path by implement GroupPath();
```
func (r *DummyResource) GroupPath() string{
	return "/demo"
}
```
- direct register hanler function;
```
func (r *DummyResource) URLPatterns() []restful.Route {
	return []restful.Route{
		{Method: http.MethodGet, Path: "/sayhello/{userid}", ResourceFuncName: "Sayhello",
			Returns: []*restful.Returns{{Code: 200}}},
                // we can register handler function to optimize performance
		{Method: http.MethodGet, Path: "/sayhello2/{userid}", ResourceFunc:r.Sayhello,
			Returns: []*restful.Returns{{Code: 200}}},
	}
}
```
- add panic recover to restful handler
```
		defer func() {
			if r := recover(); r != nil {
				openlogging.Error(fmt.Sprintf("handle request panic. path:%s, panic:%s", route.Path, r))
				if err := rep.WriteErrorString(http.StatusInternalServerError, "server got a panic, plz check log."); err != nil{
					openlogging.Error("write response failed when handler panic, err:" + err.Error())
				}
			}
		}()
```
- refactor code using interface instead reflect;