### PR TITLE
fault-injector fix #767

### DIFF
--- a/core/fault/fault_injection.go
+++ b/core/fault/fault_injection.go
@@ -3,10 +3,10 @@ package fault
 import (
 	"errors"
 	"fmt"
-	"math/rand"
-	"time"
 	"github.com/go-chassis/go-chassis/core/config/model"
 	"github.com/go-chassis/go-chassis/core/invocation"
+	"math/rand"
+	"time"
 )
 
 // constant for default values values of abort and delay percentages
@@ -14,8 +14,8 @@ const (
 	DefaultAbortPercentage int = 100
 	DefaultDelayPercentage int = 100
 
-	MaxPercentage		   int = 100
-	MinPercentage		   int = 0
+	MaxPercentage int = 100
+	MinPercentage int = 0
 )
 
 // ValidateAndApplyFault validate and apply the fault rule
@@ -78,7 +78,7 @@ func ValidateFaultDelay(fault *model.Fault) error {
 
 //ApplyFaultInjection abort/delay
 func ApplyFaultInjection(fault *model.Fault, inv *invocation.Invocation, configuredPercent int, faultType string) error {
-	if rand.Intn(MaxPercentage) + 1 <= configuredPercent {
+	if rand.Intn(MaxPercentage)+1 <= configuredPercent {
 		return injectFault(faultType, fault)
 	}
 	return nil
@@ -89,7 +89,7 @@ func injectFault(faultType string, fault *model.Fault) error {
 	if faultType == "delay" {
 		time.Sleep(fault.Delay.FixedDelay)
 	}
-	
+
 	if faultType == "abort" {
 		return errors.New("injecting abort")
 	}

--- a/core/fault/fault_injection.go
+++ b/core/fault/fault_injection.go
@@ -3,25 +3,19 @@ package fault
 import (
 	"errors"
 	"fmt"
+	"math/rand"
 	"time"
-
 	"github.com/go-chassis/go-chassis/core/config/model"
 	"github.com/go-chassis/go-chassis/core/invocation"
-	"sync"
-)
-
-var (
-	faultKeyCount             sync.Map
-	initialKeyCount           sync.Map
-	invokedCount              sync.Map
-	percenStore               sync.Map
-	abortNeeded, delayApplied bool
 )
 
 // constant for default values values of abort and delay percentages
 const (
 	DefaultAbortPercentage int = 100
 	DefaultDelayPercentage int = 100
+
+	MaxPercentage		   int = 100
+	MinPercentage		   int = 0
 )
 
 // ValidateAndApplyFault validate and apply the fault rule
@@ -31,14 +25,9 @@ func ValidateAndApplyFault(fault *model.Fault, inv *invocation.Invocation) error
 			return err
 		}
 
-		if fault.Abort != (model.Abort{}) {
-			abortNeeded = true
-		}
-
 		if err := ApplyFaultInjection(fault, inv, fault.Delay.Percent, "delay"); err != nil {
 			return err
 		}
-
 	}
 
 	if fault.Abort != (model.Abort{}) {
@@ -46,20 +35,9 @@ func ValidateAndApplyFault(fault *model.Fault, inv *invocation.Invocation) error
 			return err
 		}
 
-		// In case both delay and abort specified ,then fault injection mechanism will apply delay followed by abort
-		// percentage of fault injection will be done based on the specified percentage for delay
-		if abortNeeded && delayApplied {
-			abortNeeded = false
-			delayApplied = false
-			return errors.New("injecting abort and delay")
+		if err := ApplyFaultInjection(fault, inv, fault.Abort.Percent, "abort"); err != nil {
+			return err
 		}
-
-		if !abortNeeded {
-			if err := ApplyFaultInjection(fault, inv, fault.Abort.Percent, "abort"); err != nil {
-				return err
-			}
-		}
-
 	}
 
 	return nil
@@ -70,11 +48,11 @@ func ValidateFaultAbort(fault *model.Fault) error {
 	if fault.Abort.HTTPStatus < 100 || fault.Abort.HTTPStatus > 600 {
 		return errors.New("invalid http fault status")
 	}
-	if fault.Abort.Percent < 0 || fault.Abort.Percent > 100 {
+	if fault.Abort.Percent < MinPercentage || fault.Abort.Percent > MaxPercentage {
 		return fmt.Errorf("invalid httpfault percentage:must be in range 0..100")
 	}
 
-	if fault.Abort.Percent == 0 {
+	if fault.Abort.Percent == MinPercentage {
 		fault.Abort.Percent = DefaultAbortPercentage
 	}
 
@@ -83,11 +61,11 @@ func ValidateFaultAbort(fault *model.Fault) error {
 
 // ValidateFaultDelay checks that fault injection delay fixed delay and Percentage is valid
 func ValidateFaultDelay(fault *model.Fault) error {
-	if fault.Delay.Percent < 0.0 || fault.Delay.Percent > 100.0 {
+	if fault.Delay.Percent < MinPercentage || fault.Delay.Percent > MaxPercentage {
 		return errors.New("percentage must be in range 0..100")
 	}
 
-	if fault.Delay.Percent == 0 {
+	if fault.Delay.Percent == MinPercentage {
 		fault.Delay.Percent = DefaultDelayPercentage
 	}
 
@@ -100,88 +78,18 @@ func ValidateFaultDelay(fault *model.Fault) error {
 
 //ApplyFaultInjection abort/delay
 func ApplyFaultInjection(fault *model.Fault, inv *invocation.Invocation, configuredPercent int, faultType string) error {
-	key := inv.MicroServiceName + inv.RouteTags.String()
-	if oldPercent, ok := percenStore.Load(key); ok && configuredPercent != oldPercent {
-		resetFaultKeyCount(key)
+	if rand.Intn(MaxPercentage) + 1 <= configuredPercent {
+		return injectFault(faultType, fault)
 	}
-	percenStore.Store(key, configuredPercent)
-
-	count, exist := invokedCount.Load(key)
-	if !exist {
-		count = 1
-		value, ok := faultKeyCount.Load(key)
-		if ok {
-			faultKeyCount.Store(key, value.(int)+1)
-		} else {
-			faultKeyCount.Store(key, 1)
-		}
-	}
-
-	if exist && count == 1 {
-		value, _ := faultKeyCount.Load(key)
-		faultKeyCount.Store(key, value.(int)+1)
-	}
-
-	failureCount, _ := faultKeyCount.Load(key)
-	initialCount, ok := initialKeyCount.Load(key)
-
-	if !ok {
-		initialCount = 0
-	}
-
-	percentage := calculatePercentage(count.(int), configuredPercent)
-
-	if percentage == failureCount && initialCount != 1 {
-		value, ok := initialKeyCount.Load(key)
-		if ok {
-			initialKeyCount.Store(key, value.(int)+1)
-		} else {
-			initialKeyCount.Store(key, 1)
-		}
-
-		incrementKeyCount(key, count.(int)+1)
-		err := injectFault(faultType, fault)
-		return err
-
-	}
-
-	if percentage != failureCount && percentage > 1 {
-		value, _ := faultKeyCount.Load(key)
-		faultKeyCount.Store(key, value.(int)+1)
-		incrementKeyCount(key, count.(int)+1)
-		err := injectFault(faultType, fault)
-		return err
-	}
-	incrementKeyCount(key, count.(int)+1)
-
 	return nil
-}
-
-//incrementKeyCount increment the key count with respect to the instance which is going to serve the request
-func incrementKeyCount(key string, count int) {
-	invokedCount.Store(key, count)
-
-}
-
-//calculatePercentage calculate percentage as whole number
-func calculatePercentage(count, percent int) int {
-	return (count * percent / 100)
-}
-
-//resetFaultKeyCount reset the all count records
-func resetFaultKeyCount(key string) {
-	faultKeyCount.Delete(key)
-	initialKeyCount.Delete(key)
-	invokedCount.Delete(key)
 }
 
 //injectFault apply fault based on the type
 func injectFault(faultType string, fault *model.Fault) error {
 	if faultType == "delay" {
-		delayApplied = true
 		time.Sleep(fault.Delay.FixedDelay)
 	}
-
+	
 	if faultType == "abort" {
 		return errors.New("injecting abort")
 	}


### PR DESCRIPTION
fault-injector bug #767
修复下面问题:
1. 之前代码有多协程安全问题;
2. 之前代码，不能同时支持abort 和 delay
3. 之前的对于每个请求，不能按照percentage等概率触发； 我的理解是每次请求时独立的，应该每次等概率发生
4. 整数和浮点数比较，不安全 0 和 0.0， 100和100.0