### PR TITLE
#782 Move add schemas action to the RegisterServiceInstances method

### DIFF
--- a/core/registry/bootstrap.go
+++ b/core/registry/bootstrap.go
@@ -96,6 +96,14 @@ func RegisterService() error {
 	}
 	runtime.ServiceID = sid
 	openlogging.GetLogger().Infof("register service success:[%s] ", runtime.ServiceID)
+
+	return nil
+}
+
+// RegisterServiceInstances register micro-service instances
+func RegisterServiceInstances() error {
+	var err error
+	service := config.MicroserviceDefinition
 	runtime.Schemas, err = schema.GetSchemaIDs(service.ServiceDescription.Name)
 	for _, schemaID := range runtime.Schemas {
 		schemaInfo := schema.DefaultSchemaIDsMap[schemaID]
@@ -105,14 +113,6 @@ func RegisterService() error {
 		}
 		openlogging.Debug("upload contract to registry, " + schemaID)
 	}
-
-	return nil
-}
-
-// RegisterServiceInstances register micro-service instances
-func RegisterServiceInstances() error {
-	var err error
-	service := config.MicroserviceDefinition
 	openlogging.Debug("start to register instance.")
 	eps, err := MakeEndpointMap(config.GlobalDefinition.Cse.Protocols)
 	if err != nil {


### PR DESCRIPTION
修改原因：在正常先chassis.Init()再chassis.Run()的情况下，会依次执行RegisterService()->CreateLocalSchema()->RegisterServiceInstances()。当前AddSchemas()在RegisterService()函数中，执行到此处时还没有自动生成schema文件（schema文件在CreateLocalSchema()函数中生成），因此首次启动时不会成功注册schema。

修改内容：将AddSchemas()动作移到RegisterServiceInstances()中执行。

修复issue(s):
Fixes #782