### PR TITLE
support describing response headers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,10 +2,10 @@ module github.com/go-chassis/go-chassis
 
 require (
 	github.com/cenkalti/backoff v2.0.0+incompatible
-	github.com/emicklei/go-restful v2.11.1+incompatible
+	github.com/emicklei/go-restful v2.12.0+incompatible
 	github.com/go-chassis/foundation v0.1.1-0.20191113114104-2b05871e9ec4
 	github.com/go-chassis/go-archaius v1.2.1-0.20200309104817-8c3d4e87d33c
-	github.com/go-chassis/go-restful-swagger20 v1.0.2
+	github.com/go-chassis/go-restful-swagger20 v1.0.3-0.20200310030431-17d80f34264f
 	github.com/go-chassis/paas-lager v1.1.1
 	github.com/go-mesh/openlogging v1.0.1
 	github.com/golang/protobuf v1.3.2

--- a/go.sum
+++ b/go.sum
@@ -44,6 +44,8 @@ github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb
 github.com/emicklei/go-restful v2.8.0+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful v2.11.1+incompatible h1:CjKsv3uWcCMvySPQYKxO8XX3f9zD4FeZRsW4G0B4ffE=
 github.com/emicklei/go-restful v2.11.1+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
+github.com/emicklei/go-restful v2.12.0+incompatible h1:SIvoTSbsMEwuM3dzFirLwKc4BH6VXP5CNf+G1FfJVr4=
+github.com/emicklei/go-restful v2.12.0+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
@@ -84,6 +86,8 @@ github.com/go-chassis/go-restful-swagger20 v1.0.2-0.20191029071646-8c0119f661c5 
 github.com/go-chassis/go-restful-swagger20 v1.0.2-0.20191029071646-8c0119f661c5/go.mod h1:s+06mcAnGsVYQ2sqM4ZPiMJeRj7BTeAM/4gkhZNcsjA=
 github.com/go-chassis/go-restful-swagger20 v1.0.2 h1:Zq74EQP7IjlJK/PnYP/rF3Ptk2QskZVPoNgiVwtvpFM=
 github.com/go-chassis/go-restful-swagger20 v1.0.2/go.mod h1:ZK4hlfS6Q6E46ViezAjn6atrzoteyWl1OBEpUBn/36k=
+github.com/go-chassis/go-restful-swagger20 v1.0.3-0.20200310030431-17d80f34264f h1:5QmmNpVcGqIc6tuKNe5EAI4PA8Yn2EL9Oee7YdcJ4PE=
+github.com/go-chassis/go-restful-swagger20 v1.0.3-0.20200310030431-17d80f34264f/go.mod h1:eW62fYuzlNFDvIacB6AV8bhUDCTy4myfTCv0bT9Gbb0=
 github.com/go-chassis/paas-lager v1.0.2-0.20190328010332-cf506050ddb2 h1:iORWPbIQ81tJPKWs9TNvcjCQnqvyTlL41F9ILgiTcyM=
 github.com/go-chassis/paas-lager v1.0.2-0.20190328010332-cf506050ddb2/go.mod h1:tILYbn3+0jjCxhY6/ue9L8eRq+VJ60U6VYIdugqchB4=
 github.com/go-chassis/paas-lager v1.1.1 h1:/6wqawUGjPCpd57A/tzJzgC4MnEhNuigbayQS+2VWPQ=

--- a/server/restful/restful_server.go
+++ b/server/restful/restful_server.go
@@ -162,7 +162,7 @@ func Register2GoRestful(routeSpec Route, ws *restful.WebService, handler restful
 		rb = rb.Metadata(k, v)
 	}
 	for _, r := range routeSpec.Returns {
-		rb = rb.Returns(r.Code, r.Message, r.Model)
+		rb = rb.ReturnsWithHeaders(r.Code, r.Message, r.Model, r.Headers)
 	}
 	if routeSpec.Read != nil {
 		rb = rb.Reads(routeSpec.Read)

--- a/server/restful/router.go
+++ b/server/restful/router.go
@@ -42,6 +42,7 @@ type Returns struct {
 	Code    int // http response code
 	Message string
 	Model   interface{} // response body structure
+	Headers map[string]restful.Header
 }
 
 //Parameters describe parameters in url path or query params


### PR DESCRIPTION
当前不支持用代码定义swagger中的response headers，目前依赖的go-restful库和go-restful-swagger20库已更新，go-chassis相应做修改以支持定义response headers

相关PR：
https://github.com/emicklei/go-restful/pull/426
https://github.com/go-chassis/go-restful-swagger20/pull/5

Fixes #805