### PR TITLE
add profile interface

### DIFF
--- a/core/config/struct.go
+++ b/core/config/struct.go
@@ -45,25 +45,25 @@ type Router struct {
 
 // RouteRule is having route rule parameters
 type RouteRule struct {
-	Precedence int         `yaml:"precedence"`
-	Routes     []*RouteTag `yaml:"route"`
-	Match      Match       `yaml:"match"`
+	Precedence int         `json:"precedence" yaml:"precedence"`
+	Routes     []*RouteTag `json:"route" yaml:"route"`
+	Match      Match       `json:"match" yaml:"match"`
 }
 
 // RouteTag gives route tag information
 type RouteTag struct {
-	Tags   map[string]string `yaml:"tags"`
-	Weight int               `yaml:"weight"`
+	Tags   map[string]string `json:"tags" yaml:"tags"`
+	Weight int               `json:"weight" yaml:"weight"`
 	Label  string
 }
 
 // Match is checking source, source tags, and http headers
 type Match struct {
-	Refer       string                       `yaml:"refer"`
-	Source      string                       `yaml:"source"`
-	SourceTags  map[string]string            `yaml:"sourceTags"`
-	HTTPHeaders map[string]map[string]string `yaml:"httpHeaders"`
-	Headers     map[string]map[string]string `yaml:"headers"`
+	Refer       string                       `json:"refer" yaml:"refer"`
+	Source      string                       `json:"source" yaml:"source"`
+	SourceTags  map[string]string            `json:"sourceTags" yaml:"sourceTags"`
+	HTTPHeaders map[string]map[string]string `json:"httpHeaders" yaml:"httpHeaders"`
+	Headers     map[string]map[string]string `json:"headers" yaml:"headers"`
 }
 
 //DarkLaunchRule dark launch rule

--- a/core/registry/endpoint_struct.go
+++ b/core/registry/endpoint_struct.go
@@ -10,8 +10,8 @@ const (
 
 // Endpoint struct having full info about micro-service instance endpoint
 type Endpoint struct {
-	SSLEnabled bool
-	Address    string
+	SSLEnabled bool   `json:"sslEnabled"`
+	Address    string `json:"address"`
 }
 
 // NewEndPoint return a Endpoint object what parse from url

--- a/core/registry/healthz.go
+++ b/core/registry/healthz.go
@@ -171,6 +171,7 @@ func RefreshCache(service string, ups []*MicroServiceInstance, downs map[string]
 	if !ok || c == nil {
 		// if full new instances or at less one instance, then refresh simpleCache immediately
 		MicroserviceInstanceIndex.Set(service, ups)
+		openlogging.GetLogger().Debugf("Cached [%d] Instances of service [%s]", len(ups), service)
 		return
 	}
 
@@ -230,9 +231,10 @@ func RefreshCache(service string, ups []*MicroServiceInstance, downs map[string]
 	if len(lefts) == 0 {
 		//todo remove this when the simpleCache struct can delete the key if the input is an empty slice
 		MicroserviceInstanceIndex.Delete(service)
-	} else {
-		MicroserviceInstanceIndex.Set(service, lefts)
+		openlogging.GetLogger().Infof("Delete the service [%s] in the cache", service)
+		return
 	}
 
+	MicroserviceInstanceIndex.Set(service, lefts)
 	openlogging.GetLogger().Debugf("Cached [%d] Instances of service [%s]", len(lefts), service)
 }

--- a/core/registry/servicecenter/cache.go
+++ b/core/registry/servicecenter/cache.go
@@ -231,6 +231,7 @@ func (c *CacheManager) compareAndDeleteOutdatedProviders(newProviders sets.Strin
 	for old := range oldProviders {
 		if !newProviders.Has(old) { //provider is outdated, delete it
 			registry.MicroserviceInstanceIndex.Delete(old)
+			openlogging.GetLogger().Infof("Delete the service [%s] in the cache", old)
 		}
 	}
 }
@@ -329,7 +330,7 @@ func createAction(response *client.MicroServiceInstanceChangedEvent) {
 	msi := ToMicroServiceInstance(response.Instance).WithAppID(response.Key.AppID)
 	microServiceInstances = append(microServiceInstances, msi)
 	registry.MicroserviceInstanceIndex.Set(key, microServiceInstances)
-	openlogging.GetLogger().Debugf("Cached Instances,action is EVT_CREATE, sid = %s, instances length = %d", response.Instance.ServiceId, len(microServiceInstances))
+	openlogging.GetLogger().Infof("Cached Instances,action is EVT_CREATE, sid = %s, instances length = %d", response.Instance.ServiceId, len(microServiceInstances))
 }
 
 // deleteAction delete micro-service instance
@@ -387,5 +388,5 @@ func updateAction(response *client.MicroServiceInstanceChangedEvent) {
 		openlogging.GetLogger().Warnf("updateAction error, iid:%s", response.Instance.InstanceId)
 	}
 	registry.MicroserviceInstanceIndex.Set(key, microServiceInstances)
-	openlogging.GetLogger().Debugf("Cached Instances,action is EVT_UPDATE, sid = %s, instances length = %d", response.Instance.ServiceId, len(microServiceInstances))
+	openlogging.GetLogger().Infof("Cached Instances,action is EVT_UPDATE, sid = %s, instances length = %d", response.Instance.ServiceId, len(microServiceInstances))
 }

--- a/core/registry/struct.go
+++ b/core/registry/struct.go
@@ -35,15 +35,15 @@ type Framework struct {
 
 // MicroServiceInstance struct having full info about micro-service instance
 type MicroServiceInstance struct {
-	InstanceID      string
-	HostName        string
-	ServiceID       string
-	DefaultProtocol string
-	DefaultEndpoint string
-	Status          string
-	EndpointsMap    map[string]*Endpoint
-	Metadata        map[string]string
-	DataCenterInfo  *DataCenterInfo
+	InstanceID      string               `json:"instanceID"`
+	HostName        string               `json:"hostName"`
+	ServiceID       string               `json:"serviceID"`
+	DefaultProtocol string               `json:"defaultProtocol"`
+	DefaultEndpoint string               `json:"defaultEndpoint"`
+	Status          string               `json:"status"`
+	EndpointsMap    map[string]*Endpoint `json:"endpointsMap"`
+	Metadata        map[string]string    `json:"metadata"`
+	DataCenterInfo  *DataCenterInfo      `json:"dataCenterInfo"`
 }
 
 func (m *MicroServiceInstance) appID() string   { return m.Metadata[common.BuildinTagApp] }
@@ -84,9 +84,9 @@ type MicroServiceDependency struct {
 
 // DataCenterInfo represents micro-service data center info
 type DataCenterInfo struct {
-	Name          string
-	Region        string
-	AvailableZone string
+	Name          string `json:"name"`
+	Region        string `json:"region"`
+	AvailableZone string `json:"availableZone"`
 }
 
 // SourceInfo represent the consumer service name and metadata.

--- a/core/router/router.go
+++ b/core/router/router.go
@@ -23,6 +23,7 @@ type Router interface {
 	Init(Options) error
 	SetRouteRule(map[string][]*config.RouteRule)
 	FetchRouteRuleByServiceName(service string) []*config.RouteRule
+	ListRouteRule() map[string][]*config.RouteRule
 }
 
 // ErrNoExist means if there is no router implementation

--- a/core/router/servicecomb/route_rule_listener.go
+++ b/core/router/servicecomb/route_rule_listener.go
@@ -63,10 +63,6 @@ func (r *routeRuleEventListener) Event(e *event.Event) {
 		SaveRouteRule(service, raw, isV2)
 	case common.Delete:
 		cseRouter.DeleteRouteRuleByKey(service)
-		openlogging.Info("route rule is removed", openlogging.WithTags(
-			openlogging.Tags{
-				"key": e.Key,
-			}))
 	}
 
 }
@@ -100,10 +96,5 @@ func validateAndUpdate(routeRules []*config.RouteRule, service string) {
 	if router.ValidateRule(map[string][]*config.RouteRule{service: routeRules}) {
 		cseRouter.SetRouteRuleByKey(service, routeRules)
 		wp.GetPool().Reset(service)
-		openlogging.Info("update route rule success", openlogging.WithTags(
-			openlogging.Tags{
-				"service": service,
-				"rule":    routeRules,
-			}))
 	}
 }

--- a/core/router/servicecomb/router.go
+++ b/core/router/servicecomb/router.go
@@ -55,7 +55,7 @@ func (r *Router) LoadRules() error {
 
 	if router.ValidateRule(configs) {
 		r.routeRule = configs
-		openlogging.Debug("load route rule", openlogging.WithTags(openlogging.Tags{
+		openlogging.Info("load route rule", openlogging.WithTags(openlogging.Tags{
 			"rule": r.routeRule,
 		}))
 	}
@@ -65,15 +65,24 @@ func (r *Router) LoadRules() error {
 // SetRouteRuleByKey set route rule by key
 func (r *Router) SetRouteRuleByKey(k string, rr []*config.RouteRule) {
 	r.lock.Lock()
+	defer r.lock.Unlock()
 	r.routeRule[k] = rr
-	r.lock.Unlock()
+	openlogging.Info("update route rule success", openlogging.WithTags(
+		openlogging.Tags{
+			"service": k,
+			"rule":    rr,
+		}))
 }
 
 // DeleteRouteRuleByKey set route rule by key
 func (r *Router) DeleteRouteRuleByKey(k string) {
 	r.lock.Lock()
+	defer r.lock.Unlock()
 	delete(r.routeRule, k)
-	r.lock.Unlock()
+	openlogging.Info("route rule is removed", openlogging.WithTags(
+		openlogging.Tags{
+			"service": k,
+		}))
 }
 
 func init() {

--- a/core/router/servicecomb/router.go
+++ b/core/router/servicecomb/router.go
@@ -30,6 +30,17 @@ func (r *Router) FetchRouteRuleByServiceName(service string) []*config.RouteRule
 	return r.routeRule[service]
 }
 
+//ListRouteRule get rules for all service
+func (r *Router) ListRouteRule() map[string][]*config.RouteRule {
+	r.lock.RLock()
+	defer r.lock.RUnlock()
+	rr := make(map[string][]*config.RouteRule, len(r.routeRule))
+	for k, v := range r.routeRule {
+		rr[k] = v
+	}
+	return rr
+}
+
 //Init init router config
 func (r *Router) Init(o router.Options) error {
 	archaius.RegisterListener(&routeRuleEventListener{}, DarkLaunchKey, DarkLaunchKeyV2)

--- a/docs/intro/features.rst
+++ b/docs/intro/features.rst
@@ -13,6 +13,7 @@ Features
  - Pluggable Cipher: Able to custom your own cipher for AKSK and TLS certs
  - Handler Chain: Able to add your own code during service calling for client and server side
  - Metrics: Able to expose Prometheus metric API automatically and custom metrics reporter
+ - Profile: You can inquire route rules and discovered microservice instance information in the current program cache when the program is running
  - Tracing: Use opentracing-go as standard library, easy to integrate tracing impl
  - Logger: You can custom your own writer to sink log, by default support file and stdout
  - Hot-reconfiguraion: A lot of configuration can be reload in runtime, like loadbalancing, circuit breaker, rate limiting

--- a/docs/user-guides.rst
+++ b/docs/user-guides.rst
@@ -23,6 +23,7 @@ User guides
    user-guides/transport
    user-guides/tracing
    user-guides/metrics
+   user-guides/profile
    user-guides/log
    user-guides/tls
    user-guides/contract

--- a/docs/user-guides/profile.md
+++ b/docs/user-guides/profile.md
@@ -1,0 +1,36 @@
+# Profiling
+## Overview
+
+Go-chassis provides the ability to inquire route rules and discovered microservice instance information in the current program cache when the program is running.
+
+It allows users to easily locate issues of route and service discovery.
+
+## Configurations
+
+**cse.profile.enable**
+> *(optional, bool)* If it is true, 
+a new http API defined in "cse.profile.apipath" will serve for client.
+Default is *false*.
+
+**cse.profile.apipath**
+> *(optional, string)* It's the root path of the profile interface,
+default is */profile*.
+The specific profile path will be under this root path.
+
+
+## Example
+
+```yaml
+cse:
+  profile:
+    enable: true
+    apiPath: /profile
+```
+
+If the rest is listening on 127.0.0.1:8080, after performing the above configuration,
+you can get route rules through [http://127.0.0.1:8080/profile/route-rule](http://127.0.0.1:8080/profile/route-rule) and
+discovered microservice instance information through [http://127.0.0.1:8080/profile/discovery](http://127.0.0.1:8080/profile/discovery).
+
+Or you can get all profile data through root path [http://127.0.0.1:8080/profile](http://127.0.0.1:8080/profile).
+It includes information for all the above sub-paths.
+

--- a/pkg/profile/profile.go
+++ b/pkg/profile/profile.go
@@ -1,0 +1,61 @@
+package profile
+
+import (
+	"github.com/emicklei/go-restful"
+	"github.com/go-chassis/go-chassis/core/config"
+	"github.com/go-chassis/go-chassis/core/registry"
+	"github.com/go-chassis/go-chassis/core/router"
+	"github.com/go-mesh/openlogging"
+)
+
+// const
+const (
+	msgWriteError = "write to response err: "
+)
+
+// Profile contains route rule and discovery
+type Profile struct {
+	RouteRule map[string][]*config.RouteRule              `json:"routeRule"`
+	Discovery map[string][]*registry.MicroServiceInstance `json:"discovery"`
+}
+
+// HTTPHandleRouteRuleFunc is a go-restful handler which can expose profile of route rule in http server
+func HTTPHandleRouteRuleFunc(req *restful.Request, rep *restful.Response) {
+	if err := rep.WriteAsJson(listRouteRule()); err != nil {
+		openlogging.Error(msgWriteError + err.Error())
+	}
+}
+
+// HTTPHandleDiscoveryFunc is a go-restful handler which can expose profile of discovery in http server
+func HTTPHandleDiscoveryFunc(req *restful.Request, rep *restful.Response) {
+	if err := rep.WriteAsJson(listMicroServiceInstance()); err != nil {
+		openlogging.Error(msgWriteError + err.Error())
+	}
+}
+
+// HTTPHandleProfileFunc is a go-restful handler which can expose all profiles in http server
+func HTTPHandleProfileFunc(req *restful.Request, rep *restful.Response) {
+	if err := rep.WriteAsJson(newProfile()); err != nil {
+		openlogging.Error(msgWriteError + err.Error())
+	}
+}
+
+func newProfile() Profile {
+	return Profile{
+		RouteRule: listRouteRule(),
+		Discovery: listMicroServiceInstance(),
+	}
+}
+
+func listRouteRule() map[string][]*config.RouteRule {
+	return router.DefaultRouter.ListRouteRule()
+}
+
+func listMicroServiceInstance() map[string][]*registry.MicroServiceInstance {
+	items := registry.MicroserviceInstanceIndex.FullCache().Items()
+	m := make(map[string][]*registry.MicroServiceInstance)
+	for k, v := range items {
+		m[k] = v.Object.([]*registry.MicroServiceInstance)
+	}
+	return m
+}

--- a/pkg/profile/profile_test.go
+++ b/pkg/profile/profile_test.go
@@ -1,0 +1,25 @@
+package profile
+
+import (
+	"github.com/go-chassis/go-chassis/core/config"
+	"github.com/go-chassis/go-chassis/core/registry"
+	"github.com/go-chassis/go-chassis/core/router"
+	_ "github.com/go-chassis/go-chassis/core/router/servicecomb"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestProfile(t *testing.T) {
+	err := router.BuildRouter("cse")
+	assert.NoError(t, err)
+	rr := map[string][]*config.RouteRule{"test": {{Precedence: 10}}}
+	router.DefaultRouter.SetRouteRule(rr)
+
+	registry.MicroserviceInstanceIndex = registry.NewIndexCache()
+	registry.MicroserviceInstanceIndex.Set("test", []*registry.MicroServiceInstance{{InstanceID: "id"}})
+
+	p := newProfile()
+
+	assert.Equal(t, 10, p.RouteRule["test"][0].Precedence)
+	assert.Equal(t, "id", p.Discovery["test"][0].InstanceID)
+}

--- a/server/restful/restful_server.go
+++ b/server/restful/restful_server.go
@@ -21,6 +21,7 @@ import (
 	"github.com/go-chassis/go-chassis/core/registry"
 	"github.com/go-chassis/go-chassis/core/server"
 	"github.com/go-chassis/go-chassis/pkg/metrics"
+	"github.com/go-chassis/go-chassis/pkg/profile"
 	"github.com/go-chassis/go-chassis/pkg/runtime"
 	"github.com/go-chassis/go-chassis/pkg/util/iputil"
 	swagger "github.com/go-chassis/go-restful-swagger20"
@@ -30,10 +31,13 @@ import (
 // constants for metric path and name
 const (
 	//Name is a variable of type string which indicates the protocol being used
-	Name              = "rest"
-	DefaultMetricPath = "metrics"
-	MimeFile          = "application/octet-stream"
-	MimeMult          = "multipart/form-data"
+	Name                    = "rest"
+	DefaultMetricPath       = "metrics"
+	DefaultProfilePath      = "profile"
+	ProfileRouteRuleSubPath = "route-rule"
+	ProfileDiscoverySubPath = "discovery"
+	MimeFile                = "application/octet-stream"
+	MimeMult                = "multipart/form-data"
 )
 
 const openTLS = "?sslEnabled=true"
@@ -62,11 +66,33 @@ func newRestfulServer(opts server.Options) server.ProtocolServer {
 		openlogging.Info("Enabled metrics API on " + metricPath)
 		ws.Route(ws.GET(metricPath).To(metrics.HTTPHandleFunc))
 	}
+	addProfileRoutes(ws)
 	return &restfulServer{
 		opts:      opts,
 		container: restful.NewContainer(),
 		ws:        ws,
 	}
+}
+
+func addProfileRoutes(ws *restful.WebService) {
+	if !archaius.GetBool("cse.profile.enable", false) {
+		return
+	}
+	profilePath := archaius.GetString("cse.profile.apiPath", DefaultProfilePath)
+	if !strings.HasPrefix(profilePath, "/") {
+		profilePath = "/" + profilePath
+	}
+
+	openlogging.Info("Enabled profile API on " + profilePath)
+	ws.Route(ws.GET(profilePath).To(profile.HTTPHandleProfileFunc))
+
+	profileRouteRulePath := profilePath + "/" + ProfileRouteRuleSubPath
+	openlogging.Info("Enabled profile route-rule API on " + profileRouteRulePath)
+	ws.Route(ws.GET(profileRouteRulePath).To(profile.HTTPHandleRouteRuleFunc))
+
+	profileDiscoveryPath := profilePath + "/" + ProfileDiscoverySubPath
+	openlogging.Info("Enabled profile discovery API on " + profileDiscoveryPath)
+	ws.Route(ws.GET(profileDiscoveryPath).To(profile.HTTPHandleDiscoveryFunc))
 }
 
 // HTTPRequest2Invocation convert http request to uniform invocation data format


### PR DESCRIPTION
新增profile接口，用于查询程序当前缓存中的路由规则和已经发现的微服务实例信息。可以方便定位路由和注册发现相关的问题