### PR TITLE
light weight: decouple rate limiter to middleware

### DIFF
--- a/middleware/monitoring/handler.go
+++ b/middleware/monitoring/handler.go
@@ -31,9 +31,9 @@ import (
 
 //errors
 const (
-	MetricsLatency = "request_latency"
+	MetricsLatency = "request_process_duration"
 	MetricsRequest = "request_count"
-	MetricsErrors  = "request_errors_count"
+	MetricsErrors  = "error_response_count"
 	Name           = "monitoring"
 )
 


### PR DESCRIPTION
为了实现go chassis轻量化，引导开发者按需引用中间件