### PR TITLE
jwt middleware should install in init() function

### DIFF
--- a/docs/middleware/jwt.md
+++ b/docs/middleware/jwt.md
@@ -45,6 +45,7 @@ func (r *HelloAuth) Login(b *rf.Context) {
                    		},
 	})
 ```
+
 更改配置文件, 将basicAuth handler添加到chain中，注意作为认证鉴权，一般说的都是服务端功能，所以要放到provider chain中
 ```yaml
 cse:

--- a/examples/jwt/main.go
+++ b/examples/jwt/main.go
@@ -2,11 +2,12 @@ package main
 
 import (
 	"errors"
+	"github.com/go-chassis/go-chassis/middleware/jwt"
 	"net/http"
 	"strings"
 
 	"github.com/go-chassis/go-chassis"
-	"github.com/go-chassis/go-chassis/middleware/jwt"
+	_ "github.com/go-chassis/go-chassis/middleware/jwt"
 	"github.com/go-chassis/go-chassis/security/token"
 	rf "github.com/go-chassis/go-chassis/server/restful"
 	"github.com/go-mesh/openlogging"

--- a/go.sum
+++ b/go.sum
@@ -245,6 +245,7 @@ github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPx
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
+github.com/smartystreets/assertions v0.0.0-20190116191733-b6c0e53d7304 h1:Jpy1PXuP99tXNrhbq2BaPz9B+jNAvH1JPQQpG/9GCXY=
 github.com/smartystreets/assertions v0.0.0-20190116191733-b6c0e53d7304/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a h1:pa8hGb/2YqsZKovtsgrwcDH1RZhVbTKCjLp47XpqCDs=
 github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=

--- a/middleware/jwt/api.go
+++ b/middleware/jwt/api.go
@@ -18,7 +18,6 @@
 package jwt
 
 import (
-	"github.com/go-chassis/go-chassis/core/handler"
 	"github.com/go-chassis/go-chassis/security/token"
 	"github.com/go-mesh/openlogging"
 	"net/http"
@@ -55,10 +54,6 @@ func Use(middleware *Auth) {
 		openlogging.Info("auth all requests")
 	} else {
 		openlogging.Warn("under some condition, no auth")
-	}
-	err := handler.RegisterHandler("jwt", newHandler)
-	if err != nil {
-		openlogging.Error(err.Error())
 	}
 }
 

--- a/middleware/jwt/handler.go
+++ b/middleware/jwt/handler.go
@@ -98,3 +98,9 @@ func newHandler() handler.Handler {
 func (h *Handler) Name() string {
 	return "jwt"
 }
+func init() {
+	err := handler.RegisterHandler("jwt", newHandler)
+	if err != nil {
+		openlogging.Error(err.Error())
+	}
+}


### PR DESCRIPTION
jwt.Use这个API应当在任意位置可以调用，但是老的实现导致调这个api，handler才会被安装到框架，这样就严重影响了代码执行顺序的自由性