### PR TITLE
router management can refer to match policy

### DIFF
--- a/configserver/config_server.go
+++ b/configserver/config_server.go
@@ -135,7 +135,7 @@ func initConfigServer(endpoint string, enableSSL bool, tlsConfig *tls.Config, in
 		TLSConfig:       tlsConfig,
 		RefreshMode:     refreshMode,
 		RefreshInterval: interval,
-		AutoDiscovery:   config.GetConfigServerConf().Autodiscovery,
+		AutoDiscovery:   config.GetConfigServerConf().AutoDiscovery,
 		APIVersion:      config.GetConfigServerConf().APIVersion.Version,
 		RefreshPort:     config.GetConfigServerConf().RefreshPort,
 	}

--- a/core/config/model/chassis.go
+++ b/core/config/model/chassis.go
@@ -18,17 +18,16 @@ type DataCenterInfo struct {
 
 //CseStruct 设置注册中心SC的地址，要开哪些传输协议， 调用链信息等
 type CseStruct struct {
-	Config          Config                      `yaml:"config"`
-	Service         ServiceStruct               `yaml:"service"`
-	Protocols       map[string]Protocol         `yaml:"protocols"`
-	Handler         HandlerStruct               `yaml:"handler"`
-	References      map[string]ReferencesStruct `yaml:"references"` //Deprecated
-	FlowControl     FlowControl                 `yaml:"flowcontrol"`
-	Monitor         MonitorStruct               `yaml:"monitor"`
-	Metrics         MetricsStruct               `yaml:"metrics"`
-	Credentials     CredentialStruct            `yaml:"credentials"`
-	Transport       Transport                   `yaml:"transport"`
-	NoRefreshSchema bool                        `yaml:"noRefreshSchema"`
+	Config          Config              `yaml:"config"`
+	Service         ServiceStruct       `yaml:"service"`
+	Protocols       map[string]Protocol `yaml:"protocols"`
+	Handler         HandlerStruct       `yaml:"handler"`
+	FlowControl     FlowControl         `yaml:"flowcontrol"`
+	Monitor         MonitorStruct       `yaml:"monitor"`
+	Metrics         MetricsStruct       `yaml:"metrics"`
+	Credentials     CredentialStruct    `yaml:"credentials"`
+	Transport       Transport           `yaml:"transport"`
+	NoRefreshSchema bool                `yaml:"noRefreshSchema"`
 }
 
 //Transport defines failure
@@ -97,11 +96,10 @@ type Config struct {
 type ConfigClient struct {
 	Type            string                 `yaml:"type"`
 	ServerURI       string                 `yaml:"serverUri"`
-	TenantName      string                 `yaml:"tenantName"`
 	RefreshMode     int                    `yaml:"refreshMode"`
 	RefreshInterval int                    `yaml:"refreshInterval"`
 	RefreshPort     string                 `yaml:"refreshPort"`
-	Autodiscovery   bool                   `yaml:"autodiscovery"`
+	AutoDiscovery   bool                   `yaml:"autodiscovery"`
 	APIVersion      ConfigAPIVersionStruct `yaml:"api"`
 	Enabled         bool                   `yaml:"enabled"`
 	Dimension       map[string]string      `yaml:"dimension"`
@@ -110,12 +108,6 @@ type ConfigClient struct {
 // ConfigAPIVersionStruct is the structure for configuration API version
 type ConfigAPIVersionStruct struct {
 	Version string `yaml:"version"`
-}
-
-// ReferencesStruct references structure
-type ReferencesStruct struct {
-	Version   string `yaml:"version"`
-	Transport string `yaml:"transport"`
 }
 
 // Protocol protocol structure

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -38,9 +38,6 @@ func TestRPCInvoker_InvokeFailinChainInit(t *testing.T) {
 		"X-User": "tianxiaoliang",
 	})
 
-	config.GlobalDefinition.Cse.References = make(map[string]model.ReferencesStruct)
-	version := model.ReferencesStruct{Version: ""}
-	config.GlobalDefinition.Cse.References["Server"] = version
 	err := invoker.Invoke(ctx, "Server", "HelloServer", "SayHello", &helloworld.HelloRequest{Name: "Peter"}, replyOne,
 		core.WithMetadata(nil), core.WithStrategy(""), core.StreamingRequest())
 	assert.Error(t, err)

--- a/core/governance/process.go
+++ b/core/governance/process.go
@@ -18,7 +18,7 @@
 package governance
 
 import (
-	"github.com/go-chassis/go-chassis/core/match"
+	"github.com/go-chassis/go-chassis/core/marker"
 	"github.com/go-chassis/go-chassis/resilience/rate"
 	"github.com/go-mesh/openlogging"
 	"gopkg.in/yaml.v2"
@@ -34,7 +34,7 @@ func ProcessMatch(key string, value string) {
 		return
 	}
 	name := s[2]
-	match.SaveMatchPolicy(value, key, name)
+	marker.SaveMatchPolicy(value, key, name)
 }
 
 type limiterPolicy struct {

--- a/core/handler/invocation_mark_handler.go
+++ b/core/handler/invocation_mark_handler.go
@@ -19,7 +19,7 @@ package handler
 
 import (
 	"github.com/go-chassis/go-chassis/core/invocation"
-	"github.com/go-chassis/go-chassis/core/match"
+	"github.com/go-chassis/go-chassis/core/marker"
 )
 
 //TrafficMarker
@@ -27,7 +27,7 @@ const (
 	TrafficMarker = "traffic-marker"
 )
 
-//MarkHandler compares the Match rule with invocation and mark this invocation
+//MarkHandler compares the match rule with invocation and mark this invocation
 type MarkHandler struct {
 }
 
@@ -38,7 +38,7 @@ func (m *MarkHandler) Name() string {
 
 //Handle to handle the mart invocation
 func (m *MarkHandler) Handle(chain *Chain, i *invocation.Invocation, cb invocation.ResponseCallBack) {
-	match.Mark(i)
+	marker.Mark(i)
 	chain.Next(i, cb)
 }
 

--- a/core/handler/router_handler.go
+++ b/core/handler/router_handler.go
@@ -29,7 +29,7 @@ func (ph *RouterHandler) Handle(chain *Chain, i *invocation.Invocation, cb invoc
 	if i.Ctx != nil {
 		at, ok := i.Ctx.Value(common.ContextHeaderKey{}).(map[string]string)
 		if ok {
-			h = map[string]string(at)
+			h = at
 		}
 	}
 

--- a/core/marker/marker.go
+++ b/core/marker/marker.go
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package match
+package marker
 
 import (
 	"fmt"
@@ -30,7 +30,7 @@ import (
 
 var matches sync.Map
 
-//Operate decide value Match expression or not
+//Operate decide value match expression or not
 type Operate func(value, expression string) bool
 
 var operatorPlugin = map[string]Operate{
@@ -65,7 +65,7 @@ func Mark(inv *invocation.Invocation) {
 		return true
 	})
 	if matchName != "" {
-		//openlogging.GetLogger().Infof("the invocation math policy %s", matchName)
+		//the invocation math policy
 		inv.Mark(matchName)
 	}
 }
@@ -120,21 +120,21 @@ func headsMatch(headers map[string]string, headPolicy map[string]map[string]stri
 	return true
 }
 
-//Match compare value and expression
-func Match(strategy, value, expression string) (bool, error) {
-	f, ok := operatorPlugin[strategy]
+//match compare value and expression
+func Match(operator, value, expression string) (bool, error) {
+	f, ok := operatorPlugin[operator]
 	if !ok {
-		return false, fmt.Errorf("invalid Match method")
+		return false, fmt.Errorf("invalid match method")
 	}
 	return f(value, expression), nil
 }
 
-//SaveMatchPolicy saves Match policy
+//SaveMatchPolicy saves match policy
 func SaveMatchPolicy(value string, k string, name string) {
 	m := &config.MatchPolicy{}
 	err := yaml.Unmarshal([]byte(value), m)
 	if err != nil {
-		openlogging.Warn("invalid policy:" + k)
+		openlogging.Warn("invalid policy " + k + ":" + err.Error())
 		return
 	}
 	openlogging.GetLogger().Debugf("get policy %s %v", name, m)

--- a/core/marker/marker_test.go
+++ b/core/marker/marker_test.go
@@ -15,27 +15,27 @@
  * limitations under the License.
  */
 
-package match_test
+package marker_test
 
 import (
 	"context"
 	"github.com/go-chassis/go-chassis/client/rest"
 	"github.com/go-chassis/go-chassis/core/invocation"
-	"github.com/go-chassis/go-chassis/core/match"
+	"github.com/go-chassis/go-chassis/core/marker"
 	"github.com/stretchr/testify/assert"
 	"net/http"
 	"testing"
 )
 
 func TestMatch(t *testing.T) {
-	b, _ := match.Match("exact", "a", "a")
+	b, _ := marker.Match("exact", "a", "a")
 	assert.True(t, b)
 
-	match.Install("notEq", func(v, e string) bool {
+	marker.Install("notEq", func(v, e string) bool {
 		return !(v == e)
 	})
 
-	b, _ = match.Match("notEq", "a", "a")
+	b, _ = marker.Match("notEq", "a", "a")
 	assert.False(t, b)
 }
 
@@ -51,7 +51,7 @@ func TestSaveMatchPolicy(t *testing.T) {
           contains: "some/api"
         method: GET
 	`
-	match.SaveMatchPolicy(testMatchPolic, "servicecomb.match."+testName, testName)
+	marker.SaveMatchPolicy(testMatchPolic, "servicecomb.marker."+testName, testName)
 }
 
 func TestMark(t *testing.T) {
@@ -62,20 +62,20 @@ func TestMark(t *testing.T) {
         headers:
           user:
             exact: jason`
-		match.SaveMatchPolicy(testMatchPolic, "servicecomb.match."+testName, testName)
+		marker.SaveMatchPolicy(testMatchPolic, "servicecomb.marker."+testName, testName)
 		i := createInvoker(map[string]string{
 			"user": "jason",
 		}, http.MethodPost, "")
-		match.Mark(i)
+		marker.Mark(i)
 		assert.Equal(t, testName, i.GetMark())
 	})
 	t.Run("test match method", func(t *testing.T) {
 		testName := "match-user-json-method"
 		testMatchPolic := `
         method: GET`
-		match.SaveMatchPolicy(testMatchPolic, "servicecomb.match."+testName, testName)
+		marker.SaveMatchPolicy(testMatchPolic, "servicecomb.marker."+testName, testName)
 		i := createInvoker(nil, http.MethodGet, "")
-		match.Mark(i)
+		marker.Mark(i)
 		assert.Equal(t, testName, i.GetMark())
 	})
 
@@ -84,9 +84,9 @@ func TestMark(t *testing.T) {
 		testMatchPolic := `
         apiPath: 
           contains: "path/test"`
-		match.SaveMatchPolicy(testMatchPolic, "servicecomb.match."+testName, testName)
+		marker.SaveMatchPolicy(testMatchPolic, "servicecomb.marker."+testName, testName)
 		i := createInvoker(nil, http.MethodPost, "cse://127.0.0.1:9992/path/test")
-		match.Mark(i)
+		marker.Mark(i)
 		assert.Equal(t, testName, i.GetMark())
 	})
 }

--- a/core/marker/operator.go
+++ b/core/marker/operator.go
@@ -1,4 +1,4 @@
-package match
+package marker
 
 import (
 	"regexp"

--- a/core/marker/operator_test.go
+++ b/core/marker/operator_test.go
@@ -1,4 +1,4 @@
-package match
+package marker
 
 import (
 	"fmt"

--- a/core/registry/util.go
+++ b/core/registry/util.go
@@ -121,7 +121,7 @@ func FillUnspecifiedIP(host string) (string, error) {
 			addr = iputil.GetLocalIP()
 		}
 		if len(addr) == 0 {
-			return addr, fmt.Errorf("failed to get local IP address")
+			return addr, fmt.Errorf("auto generate IP address failed, plz manually set listenAddress and advertiseAddress")
 		}
 	}
 	return addr, nil

--- a/core/router/router_test.go
+++ b/core/router/router_test.go
@@ -1,6 +1,9 @@
 package router_test
 
 import (
+	"context"
+	"github.com/go-chassis/go-chassis/core/marker"
+	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
@@ -200,31 +203,49 @@ func TestMatch(t *testing.T) {
 	si.Name = "service"
 	si.Tags[common.BuildinTagApp] = "app"
 	si.Tags[common.BuildinTagVersion] = "0.1"
-	match := InitMatch("service", "((abc.)def.)ghi", map[string]string{"tag1": "v1"})
+	matchConf := initMatch("service", "((abc.)def.)ghi", map[string]string{"tag1": "v1"})
 	headers := map[string]string{}
 	headers["cookie"] = "abc-def-ghi"
-	assert.Equal(t, false, router.Match(match, headers, si))
+	assert.Equal(t, false, router.Match(nil, matchConf, headers, si))
 	si.Tags["tag1"] = "v1"
-	assert.Equal(t, false, router.Match(match, headers, si))
+	assert.Equal(t, false, router.Match(nil, matchConf, headers, si))
 	headers["age"] = "15"
-	assert.Equal(t, true, router.Match(match, headers, si))
-	match.HTTPHeaders["noEqual"] = map[string]string{"noEqu": "e"}
-	assert.Equal(t, true, router.Match(match, headers, si))
+	assert.Equal(t, true, router.Match(nil, matchConf, headers, si))
+	matchConf.HTTPHeaders["noEqual"] = map[string]string{"noEqu": "e"}
+	assert.Equal(t, true, router.Match(nil, matchConf, headers, si))
 	headers["noEqual"] = "noe"
-	assert.Equal(t, true, router.Match(match, headers, si))
-	match.HTTPHeaders["noLess"] = map[string]string{"noLess": "100"}
+	assert.Equal(t, true, router.Match(nil, matchConf, headers, si))
+	matchConf.HTTPHeaders["noLess"] = map[string]string{"noLess": "100"}
 	headers["noLess"] = "120"
-	assert.Equal(t, true, router.Match(match, headers, si))
-	match.HTTPHeaders["noGreater"] = map[string]string{"noGreater": "100"}
+	assert.Equal(t, true, router.Match(nil, matchConf, headers, si))
+	matchConf.HTTPHeaders["noGreater"] = map[string]string{"noGreater": "100"}
 	headers["noGreater"] = "120"
-	assert.Equal(t, false, router.Match(match, headers, si))
+	assert.Equal(t, false, router.Match(nil, matchConf, headers, si))
 
 	si.Name = "error"
-	assert.Equal(t, false, router.Match(match, headers, si))
+	assert.Equal(t, false, router.Match(nil, matchConf, headers, si))
 
 	headers["cookie"] = "7gh"
 	si.Name = "service"
-	assert.Equal(t, false, router.Match(match, headers, si))
+	assert.Equal(t, false, router.Match(nil, matchConf, headers, si))
+}
+
+func TestMatchRefer(t *testing.T) {
+	m := config.Match{}
+	m.Refer = "testMarker"
+	inv := invocation.New(context.TODO())
+	b := router.Match(inv, m, nil, nil)
+	assert.False(t, b)
+	inv.Args, _ = http.NewRequest("GET", "some/api", nil)
+	inv.Metadata = make(map[string]interface{})
+	testMatchPolicy := `
+apiPath:
+  contains: "some/api"
+method: GET
+`
+	marker.SaveMatchPolicy(testMatchPolicy, "servicecomb.marker."+m.Refer, m.Refer)
+	b = router.Match(inv, m, nil, nil)
+	assert.True(t, b)
 }
 
 func TestFitRate(t *testing.T) {
@@ -268,9 +289,9 @@ func InitDests() map[string][]*config.RouteRule {
 	r1.Routes = InitTags("0.11", "0.2")
 	r2.Routes = InitTags("1.1", "1.2")
 	r3.Routes = InitTags("2.1", "2.2")
-	match1 := InitMatch("source", "((abc.)def.)ghi", map[string]string{"tag1": "v1"})
-	match2 := InitMatch("source", "notmatch", map[string]string{"tag1": "v1"})
-	match3 := InitMatch("source1", "((abc.)def.)ghi", map[string]string{"tag1": "v1"})
+	match1 := initMatch("source", "((abc.)def.)ghi", map[string]string{"tag1": "v1"})
+	match2 := initMatch("source", "notmatch", map[string]string{"tag1": "v1"})
+	match3 := initMatch("source1", "((abc.)def.)ghi", map[string]string{"tag1": "v1"})
 	r2.Match = match2
 	r1.Match = match1
 	r3.Match = match3
@@ -290,7 +311,7 @@ func InitTags(v1 string, v2 string) []*config.RouteTag {
 	return tags
 }
 
-func InitMatch(source string, pat string, tags map[string]string) config.Match {
+func initMatch(source string, pat string, tags map[string]string) config.Match {
 	match := config.Match{}
 	match.Source = source
 	match.SourceTags = tags

--- a/docs/user-guides/router.md
+++ b/docs/user-guides/router.md
@@ -36,38 +36,17 @@ servicecomb:
                 app: {appId}
         - precedence: {number1}
           match:        
-            refer: {sourceTemplateName} #参考某个source模板ID
+            refer: {matchPolicy} #参考某个match policy
           route:
             - weight: {percent}
               tags:
                 version: {version2}
                 app: {appId}        
-sourceTemplate:  #定义source模板
-  {templateName}: # source 模板ID
-    source: {sourceServiceName} 
-    sourceTags：
-      {tag}：{value}
-    headers:
-      {key0}:
-        regex: {regex}
-      {key1}
-        exact: {=?}
-      {key2}:
-        noEqu: {!=?}
-      {key3}
-        greater: {>?}    
-      {key4}:
-        less: {<?}
-      {key5}
-        noLess: {>=?}      
-      {key6}:
-        noGreater: {<=?}
 ```
 
 路由规则说明：
 
-- 匹配特定请求由match配置，匹配条件是：source（源服务名）、source  tags 及headers，另外也可以使用refer字段来使用source模板进行匹配。
-- Match中的Source Tags用于和服务调用请求中的sourceInfo中的tags 进行逐一匹配。
+- 匹配特定请求由match配置，使用refer字段引用已经定义好的match规则
 - Header中的字段的匹配支持正则, 等于, 小于, 大, 于不等于等匹配方式。
 - 如果未定义match，则可匹配任何请求。
 - 转发权重定义在routeRule.{targetServiceName}.route下，由weight配置。
@@ -140,7 +119,7 @@ servicecomb:
 
 ```yaml
 match:
-  refer: {templateName}
+  refer: {matchPolicyName}
   source: {sourceServiceName}
   headers:
     {key}:
@@ -152,7 +131,7 @@ match:
 请求的匹配规则属性配置如下：
 
 **refer**
-> *(optional, string)* 引用的匹配规则模板名称，用户可选择在sourceTemplate中定义匹配规则模板，并在此处引用。若引用了匹配规则模板，则其他配置项不用配置。 
+> *(optional, string)* 引用的match policy名称，用户可选择指定引用一个match policy，一旦符合请求特征，那就是匹配了
 
 **source**
 > *(optional, string)* 表示发送请求的服务，和consumer是一个意义。
@@ -257,19 +236,18 @@ route:
 
 ```yaml
 servicecomb:
-    routeRule: 
-      Carts: |
-        - precedence: 2
-          match:
-            refer: vmall-with-special-header
-          route:
-            - weight: 100           
-              tags:            
-                version: 2.0
-    sourceTemplate:
-      vmall-with-special-header:
-        source: vmall
-        headers:
-          cookie:
-            regex: "^(.*?;)?(user=jason)(;.*)?$"
+  routeRule: 
+    Carts: |
+      - precedence: 2
+        match:
+          refer: user-with-special-header
+        route:
+          - weight: 100           
+            tags:            
+              version: 2.0
+  match:
+    user-with-special-header:
+      headers:
+        cookie:
+          regex: "^(.*?;)?(user=jason)(;.*)?$"
 ```

--- a/pkg/util/iputil/ip.go
+++ b/pkg/util/iputil/ip.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"github.com/go-mesh/openlogging"
+	"log"
 	"net"
 	"net/http"
 	"net/url"
@@ -19,12 +20,14 @@ func Localhost() string { return "127.0.0.1" }
 func GetLocalIP() string {
 	addresses, err := net.InterfaceAddrs()
 	if err != nil {
+		log.Println(err)
 		return ""
 	}
 	for _, address := range addresses {
 		// Parse IP
 		var ip net.IP
 		if ip, _, err = net.ParseCIDR(address.String()); err != nil {
+			log.Println(err)
 			return ""
 		}
 		// Check if valid global unicast IPv4 address

--- a/pkg/util/iputil/ip_test.go
+++ b/pkg/util/iputil/ip_test.go
@@ -10,8 +10,9 @@ import (
 	"testing"
 )
 
-func TestGetLocapIp(t *testing.T) {
+func TestGetLocalIp(t *testing.T) {
 	localip := iputil.GetLocalIP()
+	t.Log(localip)
 	assert.NotNil(t, localip)
 }
 


### PR DESCRIPTION
路由策略管理变得更加强大：
- 可以引用match策略定义，只需要通过名字即可引用复杂的模板定义
- source template功能被移除，被上述能力替代

模板的匹配能力可以参考 #754 

需要在handler chain中配置“marker”用来进行流量标记


其他变动：

删除依赖定义的能力，没有实际业务场景