### PR TITLE
bug fix: monitoring should call original call back func

### DIFF
--- a/docs/user-guides/marker.md
+++ b/docs/user-guides/marker.md
@@ -29,7 +29,9 @@ cse:
       Provider:
         default: traffic-marker,rate-limiter
 ```
-# co work with feature
+## Supported features
+More feature will will support marker, currently support below features:
+
 - router management
 - rate limiter
 

--- a/middleware/monitoring/handler.go
+++ b/middleware/monitoring/handler.go
@@ -76,14 +76,15 @@ func (ph *Handler) Handle(chain *handler.Chain, i *invocation.Invocation, cb inv
 			}
 			err := metrics.CounterAdd(MetricsErrors, 1, m)
 			if err != nil {
-				openlogging.Fatal(err.Error())
+				openlogging.Error(err.Error())
 			}
 		}
 		duration := time.Since(start)
 		err := metrics.SummaryObserve(MetricsLatency, float64(duration.Milliseconds()), labelMap)
 		if err != nil {
-			openlogging.Fatal(err.Error())
+			openlogging.Error(err.Error())
 		}
+		cb(resp)
 	})
 
 }

--- a/middleware/monitoring/handler_test.go
+++ b/middleware/monitoring/handler_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/go-chassis/go-chassis/pkg/metrics"
 	"github.com/prometheus/common/expfmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -72,9 +73,14 @@ func TestNewWithChain(t *testing.T) {
 	c.ServeHTTP(resp, r)
 	c.ServeHTTP(resp, r)
 
+	resp2 := httptest.NewRecorder()
 	r, _ = http.NewRequest("GET", "/err", nil)
-	c.ServeHTTP(resp, r)
-	c.ServeHTTP(resp, r)
+	c.ServeHTTP(resp2, r)
+	body, err := ioutil.ReadAll(resp2.Body)
+	assert.NoError(t, err)
+	assert.Equal(t, "err", string(body))
+	assert.Equal(t, http.StatusInternalServerError, resp2.Code)
+	c.ServeHTTP(resp2, r)
 
 	mfs, err := metrics.GetSystemPrometheusRegistry().Gather()
 	assert.NoError(t, err)


### PR DESCRIPTION
监控中间件没有对业务结果进行返回，导致http response错误