### PR TITLE
if jwt is not init, skip auth

### DIFF
--- a/middleware/jwt/handler.go
+++ b/middleware/jwt/handler.go
@@ -44,6 +44,11 @@ type Handler struct {
 
 //Handle intercept unauthorized request
 func (h *Handler) Handle(chain *handler.Chain, i *invocation.Invocation, cb invocation.ResponseCallBack) {
+	if auth == nil {
+		//jwt is not initialized, then skip authentication, do not report error
+		chain.Next(i, cb)
+		return
+	}
 	var req *http.Request
 	if r, ok := i.Args.(*http.Request); ok {
 		req = r


### PR DESCRIPTION
jwt一般会配置在handler chain中，但是业务服务可能会有启用或未启用认证的场景，未启用场景下，不该进行jwt认证