### PR TITLE
enhance marker match policy

### DIFF
--- a/core/config/struct.go
+++ b/core/config/struct.go
@@ -84,11 +84,16 @@ type RuleItem struct {
 }
 
 //MatchPolicy specify a request mach policy
+type MatchPolicies struct {
+	Matches []MatchPolicy `yaml:"matches"`
+}
+
+//MatchPolicy specify a request mach policy
 type MatchPolicy struct {
 	TrafficMarkPolicy string                       `yaml:"trafficMarkPolicy"`
 	Headers           map[string]map[string]string `yaml:"headers"`
 	APIPaths          map[string]string            `yaml:"apiPath"`
-	Method            string                       `yaml:"method"`
+	Method            []string                     `yaml:"method"`
 }
 
 //LimiterConfig is rate limiter policy

--- a/core/governance/governance_test.go
+++ b/core/governance/governance_test.go
@@ -26,7 +26,7 @@ import (
 
 func TestInstallProcess(t *testing.T) {
 	archaius.Init(archaius.WithMemorySource())
-	archaius.Set("servicecomb.customResource.aResource", "test")
+	archaius.Set("servicecomb.customResource.name1", "test")
 	var value string
 	governance.InstallProcessor("servicecomb.customResource", func(k, v string) error {
 		t.Log("process:" + k)

--- a/core/governance/process.go
+++ b/core/governance/process.go
@@ -35,7 +35,7 @@ func ProcessMatch(key string, value string) error {
 		return errors.New("invalid key:" + key)
 	}
 	name := s[2]
-	return marker.SaveMatchPolicy(value, key, name)
+	return marker.SaveMatchPolicy(name, value, key)
 }
 
 type LimiterPolicy struct {

--- a/core/handler/invocation_mark_handler_test.go
+++ b/core/handler/invocation_mark_handler_test.go
@@ -37,15 +37,17 @@ func TestMarkHandler_Handle(t *testing.T) {
 
 	archaius.Init(archaius.WithMemorySource())
 	var yamlContent = `
-headers:
-  cookie:
-    regex: "^(.*?;)?(user=jason)(;.*)?$"
-  user:
-    exact: jason
-apiPath:
-  contains: "path/test"
-  exact: "/test2"
-method: GET
+matches:
+  - headers:
+      cookie:
+        regex: "^(.*?;)?(user=jason)(;.*)?$"
+      user:
+        exact: jason
+    apiPath:
+      contains: "path/test"
+    method: [GET]
+  - apiPath:
+      exact: "/test2"
 `
 	archaius.Set(strings.Join([]string{governance.KindMatchPrefix, "match-user-json"}, "."), yamlContent)
 	governance.Init()
@@ -109,7 +111,8 @@ func TestMarkHandler_Handle2(t *testing.T) {
 	config.GlobalDefinition.ServiceComb.Handler.Chain.Consumer[handler.TrafficMarker] = handler.TrafficMarker
 	archaius.Init(archaius.WithMemorySource())
 	var yamlContent = `
-method: GET
+matches:
+  - method: [GET]
 `
 	archaius.Set(strings.Join([]string{governance.KindMatchPrefix, "match-user-json"}, "."), yamlContent)
 	governance.Init()
@@ -150,18 +153,21 @@ func TestMarkHandler_HandleMutilePolicy(t *testing.T) {
 
 	archaius.Init(archaius.WithMemorySource())
 	var yamlContent = `
-headers:
-  cookie:
-    regex: "^(.*?;)?(user=jason)(;.*)?$"
-  user:
-    exact: jason
-apiPath:
-  contains: "path/test"
-  exact: "/test2"
-method: GET
+matches:
+  - headers:
+      cookie:
+        regex: "^(.*?;)?(user=jason)(;.*)?$"
+      user:
+        exact: jason
+    apiPath:
+      contains: "path/test"
+    method: [GET]
+  - apiPath:
+      contains: "test2"
 `
 	var yamlContent2 = `
-method: POST 
+matches:
+  - method: [POST] 
 `
 	archaius.Set(strings.Join([]string{governance.KindMatchPrefix, "match-user-json"}, "."), yamlContent)
 	archaius.Set(strings.Join([]string{governance.KindMatchPrefix, "match-user-json-2"}, "."), yamlContent2)

--- a/core/router/router_test.go
+++ b/core/router/router_test.go
@@ -238,11 +238,12 @@ func TestMatchRefer(t *testing.T) {
 	inv.Args, _ = http.NewRequest("GET", "some/api", nil)
 	inv.Metadata = make(map[string]interface{})
 	testMatchPolicy := `
-apiPath:
-  contains: "some/api"
-method: GET
+matches:
+  - apiPath:
+      contains: "some/api"
+    method: [GET]
 `
-	marker.SaveMatchPolicy(testMatchPolicy, "servicecomb.marker."+m.Refer, m.Refer)
+	marker.SaveMatchPolicy(m.Refer, testMatchPolicy, "servicecomb.marker."+m.Refer)
 	b = router.Match(inv, m, nil, nil)
 	assert.True(t, b)
 }

--- a/docs/user-guides/marker.md
+++ b/docs/user-guides/marker.md
@@ -41,15 +41,18 @@ you can mark traffic and then limit the rate of this kind of traffic
 servicecomb:
   match:
     traffic-to-some-api-from-jack: |
-        headers:
-          cookie:
-            regex: "^(.*?;)?(user=jack)(;.*)?$"
-          os:
-            contains: linux
-        apiPath:
-          exact: "/some/api" 
-        method: GET 
-        trafficMarkPolicy: once
+        matches:
+          - headers:
+              cookie:
+                regex: "^(.*?;)?(user=jack)(;.*)?$"
+              os:
+                contains: linux
+            apiPath:
+              exact: "/some/api" 
+            method: 
+              - GET 
+              - POST
+            trafficMarkPolicy: once
   rateLimiting:
     limiterPolicy1: |
       match: traffic-to-some-api-from-jack

--- a/docs/user-guides/router.md
+++ b/docs/user-guides/router.md
@@ -178,7 +178,6 @@ func init() {
 - 在配置中使用
 ```yaml
 match:
-  source: vmall
   headers:
     cookie:
       range: "0-100"

--- a/examples/marker/conf/chassis.yaml
+++ b/examples/marker/conf/chassis.yaml
@@ -10,14 +10,15 @@ servicecomb:
     chain:
       Provider:
         default: traffic-marker,rate-limiter
-servicecomb:
   match:
     markGetRequest: |
-      method: GET
-      apiPath:
-        exact: "/hello"
+      matches:
+        - method:
+            - GET
+          apiPath:
+            exact: "/hello"
   rateLimiting:
     limiteGet: |
       match: markGetRequest
-      rate: 10
-      burst: 1
+      rate: 100
+      burst: 20

--- a/middleware/ratelimiter/handler.go
+++ b/middleware/ratelimiter/handler.go
@@ -41,7 +41,7 @@ func (h *Handler) Handle(chain *handler.Chain, inv *invocation.Invocation, cb in
 		chain.Next(inv, cb)
 		return
 	}
-	if rate.GetRateLimiters().TryAccept(inv.GetMark(), math.MaxInt32, 0) {
+	if rate.GetRateLimiters().TryAccept(inv.GetMark(), math.MaxInt32, 1) {
 		chain.Next(inv, cb)
 		return
 	}

--- a/middleware/ratelimiter/handler_test.go
+++ b/middleware/ratelimiter/handler_test.go
@@ -21,17 +21,19 @@ func init() {
 func TestHandler_Handle(t *testing.T) {
 	testName := "api1"
 	testMatchPolicy := `
-apiPath:
-  contains: "api/1"
+matches:
+  - apiPath:
+      contains: "api/1"
+    method: [GET]
 `
-	marker.SaveMatchPolicy(testMatchPolicy, "servicecomb.marker."+testName, testName)
-
+	err := marker.SaveMatchPolicy(testName, testMatchPolicy, "servicecomb.marker."+testName)
+	assert.NoError(t, err)
 	b := []byte(`
 match: api1
 rate: 10
 burst: 2
 `)
-	err := governance.ProcessLimiter("servicecomb.rateLimiting.test", string(b))
+	err = governance.ProcessLimiter("servicecomb.rateLimiting.test", string(b))
 	assert.NoError(t, err)
 
 	c := handler.Chain{}

--- a/resilience/rate/limiter.go
+++ b/resilience/rate/limiter.go
@@ -76,6 +76,7 @@ func (qpsL *Limiters) UpdateRateLimit(name string, qps, burst int) {
 		"event":  "update",
 		"mark":   name,
 		"qps":    qps,
+		"burst":  burst,
 	}))
 	qpsL.addLimiter(name, qps, burst)
 }


### PR DESCRIPTION
增强了流量标记的规则能力，提供了更强的"或"语义，允许定义多个matches规则
```yaml
servicecomb:
  match:
    accessAdminAPI: |
      matches:
          - apiPath:
              exact: "/role"
          - apiPath:
              exact: "/account"

```