### PR TITLE
修复router中发现的bug

### DIFF
--- a/core/router/router.go
+++ b/core/router/router.go
@@ -56,7 +56,7 @@ func Route(header map[string]string, si *registry.SourceInfo, inv *invocation.In
 	rules := SortRules(inv.MicroServiceName)
 	for _, rule := range rules {
 		if Match(inv, rule.Match, header, si) {
-			tag := FitRate(rule.Routes, inv.MicroServiceName)
+			tag := FitRate(rule.Routes, GenWeightPoolKey(inv.MicroServiceName, rule.Precedence))
 			inv.RouteTags = routeTagToTags(tag)
 			break
 		}
@@ -72,9 +72,8 @@ func FitRate(tags []*config.RouteTag, dest string) *config.RouteTag {
 
 	pool, ok := wp.GetPool().Get(dest)
 	if !ok {
-		// first request route to tags[0]
-		wp.GetPool().Set(dest, wp.NewPool(tags...))
-		return tags[0]
+		pool = wp.NewPool(tags...)
+		wp.GetPool().Set(dest, pool)
 	}
 	return pool.PickOne()
 }

--- a/core/router/router_config.go
+++ b/core/router/router_config.go
@@ -3,6 +3,7 @@ package router
 import (
 	"crypto/tls"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/go-chassis/go-chassis/v2/core/config"
@@ -100,4 +101,9 @@ func routeTagToTags(t *config.RouteTag) utiltags.Tags {
 		return tag
 	}
 	return tag
+}
+
+// GenWeightPoolKey returns weight pool cache key
+func GenWeightPoolKey(dest string, precedence int) string {
+	return dest + "." + strconv.Itoa(precedence)
 }

--- a/core/router/router_config_test.go
+++ b/core/router/router_config_test.go
@@ -36,3 +36,9 @@ func TestInit(t *testing.T) {
 	})
 
 }
+
+func BenchmarkGenWeightPoolKey(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		router.GenWeightPoolKey("test", 1)
+	}
+}

--- a/core/router/servicecomb/route_rule_listener.go
+++ b/core/router/servicecomb/route_rule_listener.go
@@ -95,6 +95,8 @@ func SaveRouteRule(service string, raw string, isV2 bool) {
 func validateAndUpdate(routeRules []*config.RouteRule, service string) {
 	if router.ValidateRule(map[string][]*config.RouteRule{service: routeRules}) {
 		cseRouter.SetRouteRuleByKey(service, routeRules)
-		wp.GetPool().Reset(service)
+		for _, routeRule := range routeRules {
+			wp.GetPool().Reset(router.GenWeightPoolKey(service, routeRule.Precedence))
+		}
 	}
 }


### PR DESCRIPTION
#930
1.修复当一个服务配置了多个优先级的分发策略情况下，第一个匹配的优先级下的分发策略就会被当做这个服务其他优先级的分发策略，这样当满足其他优先级的请求就会导致该优先级下的分发策略失效。
2.修复当一个优先配置了权重为0的tag，则第一个满足这个优先级的第一个请求就会返回权重为0的tag
3.增加单元测试