### PR TITLE
more friendly for user who don't want to use service discovery

### DIFF
--- a/core/core_test.go
+++ b/core/core_test.go
@@ -47,7 +47,7 @@ func TestRestInvoker_ContextDo(t *testing.T) {
 	req, _ := rest.NewRequest("GET", "http://Server/sayhello/myidtest", nil)
 	httputil.SetContentType(req, "application/json")
 	//use the invoker like http client.
-	_, err := restinvoker.ContextDo(context.TODO(), req, core.WithEndpoint("0.0.0.0"), core.WithProtocol("rest"), core.WithFilters(""))
+	_, err := restinvoker.ContextDo(context.TODO(), req, core.WithoutSD(), core.WithFilters(""))
 	assert.Error(t, err)
 }
 
@@ -59,7 +59,7 @@ func TestOptions(t *testing.T) {
 	inv := core.StreamingRequest()
 	assert.NotEmpty(t, inv)
 
-	inv = core.WithEndpoint("0.0.0.0")
+	inv = core.WithoutSD()
 	assert.NotEmpty(t, inv)
 
 	inv = core.WithProtocol("0.0")

--- a/core/handler/loadbalance_handler.go
+++ b/core/handler/loadbalance_handler.go
@@ -74,6 +74,10 @@ func (lb *LBHandler) getEndpoint(i *invocation.Invocation, lbConfig control.Load
 
 // Handle to handle the load balancing
 func (lb *LBHandler) Handle(chain *Chain, i *invocation.Invocation, cb invocation.ResponseCallBack) {
+	if i.Endpoint != "" {
+		chain.Next(i, cb)
+		return
+	}
 	lbConfig := control.DefaultPanel.GetLoadBalancing(*i)
 	if !lbConfig.RetryEnabled {
 		lb.handleWithNoRetry(chain, i, lbConfig, cb)

--- a/core/options.go
+++ b/core/options.go
@@ -22,8 +22,7 @@ type InvokeOptions struct {
 	DialTimeout time.Duration
 	// Request/Response timeout
 	RequestTimeout time.Duration
-	// end to end, Directly call
-	Endpoint string
+	DisableSD      bool
 	// end to end, Directly call
 	Protocol string
 	Port     string
@@ -83,10 +82,12 @@ func StreamingRequest() InvocationOption {
 	}
 }
 
-// WithEndpoint is request option
-func WithEndpoint(ep string) InvocationOption {
+// WithoutSD will skip client-side load balancing phase.
+// it means, go chassis can work without service discovery(ike consul, etcd, eureka,kubernetes).
+// use this API, when you don't want to make your micro service depend on a centralized service.
+func WithoutSD() InvocationOption {
 	return func(o *InvokeOptions) {
-		o.Endpoint = ep
+		o.DisableSD = true
 	}
 }
 
@@ -127,7 +128,7 @@ func WithRouteTags(t map[string]string) InvocationOption {
 }
 
 // getOpts is to get the options
-func getOpts(microservice string, options ...InvocationOption) InvokeOptions {
+func getOpts(options ...InvocationOption) InvokeOptions {
 	opts := InvokeOptions{}
 	for _, o := range options {
 		o(&opts)
@@ -135,9 +136,16 @@ func getOpts(microservice string, options ...InvocationOption) InvokeOptions {
 	return opts
 }
 
-// wrapInvocationWithOpts is wrap invocation with options
+// wrapInvocationWithOpts wrap invocation with options
 func wrapInvocationWithOpts(i *invocation.Invocation, opts InvokeOptions) {
-	i.Endpoint = opts.Endpoint
+	if opts.DisableSD { // client side load balancing handler will not work
+		if opts.Port != "" {
+			i.Endpoint = i.MicroServiceName + ":" + opts.Port
+		} else {
+			i.Endpoint = i.MicroServiceName
+		}
+	}
+
 	i.Protocol = opts.Protocol
 	i.Strategy = opts.StrategyFunc
 	i.Filters = opts.Filters

--- a/core/rest_invoker.go
+++ b/core/rest_invoker.go
@@ -13,9 +13,10 @@ import (
 	"github.com/go-chassis/go-chassis/v2/pkg/util"
 )
 
+//schemas
 const (
-	//HTTP is url schema name
-	HTTP = "http"
+	HTTP  = "http"
+	HTTPS = "https"
 )
 
 // RestInvoker is rest invoker
@@ -40,8 +41,8 @@ func NewRestInvoker(opt ...Option) *RestInvoker {
 // ContextDo is for requesting the API
 // by default if http status is 5XX, then it will return error
 func (ri *RestInvoker) ContextDo(ctx context.Context, req *http.Request, options ...InvocationOption) (*http.Response, error) {
-	if req.URL.Scheme != HTTP {
-		return nil, fmt.Errorf("scheme invalid: %s, only support {http}://", req.URL.Scheme)
+	if req.URL.Scheme != HTTP && req.URL.Scheme != HTTPS {
+		return nil, fmt.Errorf("scheme invalid: %s, only support http(s)://", req.URL.Scheme)
 	}
 	common.SetXCSEContext(map[string]string{common.HeaderSourceName: runtime.ServiceName}, req)
 	// set headers to Ctx
@@ -56,17 +57,20 @@ func (ri *RestInvoker) ContextDo(ctx context.Context, req *http.Request, options
 		}
 	}
 
-	opts := getOpts(req.Host, options...)
-	service, port, _ := util.ParseServiceAndPort(req.Host)
+	opts := getOpts(options...)
+	service, port, err := util.ParseServiceAndPort(req.Host)
+	if err != nil {
+		return nil, err
+	}
 	opts.Protocol = common.ProtocolRest
 	opts.Port = port
 
 	resp := rest.NewResponse()
 
 	inv := invocation.New(ctx)
-
-	wrapInvocationWithOpts(inv, opts)
 	inv.MicroServiceName = service
+	wrapInvocationWithOpts(inv, opts)
+
 	//TODO load from openAPI schema
 	inv.SchemaID = port
 	if inv.SchemaID == "" {
@@ -79,8 +83,7 @@ func (ri *RestInvoker) ContextDo(ctx context.Context, req *http.Request, options
 
 	inv.SetMetadata(common.RestMethod, req.Method)
 
-	err := ri.invoke(inv)
-
+	err = ri.invoke(inv)
 	if err == nil {
 		setCookieToCache(*inv, getNamespaceFromMetadata(opts.Metadata))
 	}

--- a/core/rpc_invoker.go
+++ b/core/rpc_invoker.go
@@ -25,21 +25,19 @@ func NewRPCInvoker(opt ...Option) *RPCInvoker {
 			opts: opts,
 		},
 	}
-	//clientPluginName := os.Getenv("rpc_client_plugin")
-	//clientF := client.GetClientNewFunc(clientPluginName)
 	return ri
 }
 
 // Invoke is for to invoke the functions during API calls
 func (ri *RPCInvoker) Invoke(ctx context.Context, microServiceName, schemaID, operationID string, arg interface{}, reply interface{}, options ...InvocationOption) error {
-	opts := getOpts(microServiceName, options...)
+	opts := getOpts(options...)
 	if opts.Protocol == "" {
 		opts.Protocol = common.ProtocolHighway
 	}
 
 	i := invocation.New(ctx)
-	wrapInvocationWithOpts(i, opts)
 	i.MicroServiceName = microServiceName
+	wrapInvocationWithOpts(i, opts)
 	i.SchemaID = schemaID
 	i.OperationID = operationID
 	i.Args = arg

--- a/examples/simple/README.md
+++ b/examples/simple/README.md
@@ -1,0 +1,21 @@
+No service discovery
+
+
+
+Run rest server
+
+```sh 
+cd server
+export CHASSIS_HOME=$PWD
+go run main.go
+
+```
+
+Run Rest client
+```sh 
+ cd client
+ export CHASSIS_HOME=$PWD
+ go run main.go
+
+ 
+```

--- a/examples/simple/client/conf/chassis.yaml
+++ b/examples/simple/client/conf/chassis.yaml
@@ -1,0 +1,4 @@
+---
+servicecomb:
+  registry:
+    disabled: true

--- a/examples/simple/client/conf/microservice.yaml
+++ b/examples/simple/client/conf/microservice.yaml
@@ -1,0 +1,3 @@
+servicecomb:
+  service:
+    name: RESTClient

--- a/examples/simple/client/main.go
+++ b/examples/simple/client/main.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"context"
+	"github.com/go-chassis/openlog"
+
+	"github.com/go-chassis/go-chassis/v2"
+	_ "github.com/go-chassis/go-chassis/v2/bootstrap"
+	"github.com/go-chassis/go-chassis/v2/client/rest"
+	"github.com/go-chassis/go-chassis/v2/core"
+	"github.com/go-chassis/go-chassis/v2/pkg/util/httputil"
+)
+
+//if you use go run main.go instead of binary run, plz export CHASSIS_HOME=/{path}/{to}/rest/client/
+func main() {
+	//Init framework
+	if err := chassis.Init(); err != nil {
+		openlog.Error("Init failed." + err.Error())
+		return
+	}
+
+	req, err := rest.NewRequest("GET", "http://127.0.0.1:5001/hello", nil)
+	if err != nil {
+		openlog.Error("new request failed.")
+		return
+	}
+	resp, err := core.NewRestInvoker().ContextDo(context.TODO(), req, core.WithoutSD())
+	if err != nil {
+		openlog.Error("do request failed.")
+		return
+	}
+	defer resp.Body.Close()
+	openlog.Info("REST Server sayhello[GET]: " + string(httputil.ReadBody(resp)))
+}

--- a/examples/simple/server/conf/chassis.yaml
+++ b/examples/simple/server/conf/chassis.yaml
@@ -1,0 +1,7 @@
+---
+servicecomb:
+  registry:
+    disabled: true
+  protocols:
+    rest:
+      listenAddress: 127.0.0.1:5001

--- a/examples/simple/server/conf/microservice.yaml
+++ b/examples/simple/server/conf/microservice.yaml
@@ -1,0 +1,3 @@
+servicecomb:
+  service:
+    name: noName

--- a/examples/simple/server/main.go
+++ b/examples/simple/server/main.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"fmt"
+	"github.com/go-chassis/go-chassis/v2"
+	rf "github.com/go-chassis/go-chassis/v2/server/restful"
+	"github.com/go-chassis/openlog"
+	"net/http"
+)
+
+//if you use go run main.go instead of binary run, plz export CHASSIS_HOME=/{path}/{to}/server/
+
+type RestFulHello struct {
+}
+
+func (r *RestFulHello) Root(b *rf.Context) {
+	b.Write([]byte(fmt.Sprintf("hello %s", b.ReadRequest().RemoteAddr)))
+}
+
+//URLPatterns helps to respond for corresponding API calls
+func (r *RestFulHello) URLPatterns() []rf.Route {
+	return []rf.Route{
+		{Method: http.MethodGet, Path: "/hello", ResourceFunc: r.Root,
+			Returns: []*rf.Returns{{Code: 200}}},
+	}
+}
+func main() {
+	chassis.RegisterSchema("rest", &RestFulHello{})
+	if err := chassis.Init(); err != nil {
+		openlog.Fatal("Init failed." + err.Error())
+		return
+	}
+	chassis.Run()
+}


### PR DESCRIPTION
微服务架构模式只是go chassis的核心功能之一，所以做了一个设计保证和微服务架构模式解耦。但是体验并不好

过去的设计要通过WithEndpoint(endpoint)接口手工指定微服务入口，强制决定服务地址来绕过客户端负载均衡（包含服务发现）。但其实这个方法的参数是个冗余信息，还可以填写的完全不一致，导致用户困惑

比如重复信息
```go
invoker:= core.NewRestInvoker()
req, _ := rest.NewRequest("GET", "http://127.0.0.1/hello", nil)
invoker.ContextDo(context.TODO(), req, core.WithEndpoint("127.0.0.1"))
```
比如导致困惑
```go
req, _ := rest.NewRequest("GET", "http://orderService/hello", nil)
invoker.ContextDo(context.TODO(), req, core.WithEndpoint("127.0.0.1"))
```


**新的API设计不再需要传参，而是复用request内的host信息，方便许多**
比如利用kubernetes的原生容器网络，或者结合任意服务网格
```go
req, _ := rest.NewRequest("GET", "http://orderService:8080/hello", nil)
invoker.ContextDo(context.TODO(), req, core.WithoutSD())
```

比如直接使用网络地址
```go
req, _ := rest.NewRequest("GET", "http://127.0.0.1:8080/hello", nil)
invoker.ContextDo(context.TODO(), req, core.WithoutSD())
```