### PR TITLE
为Client增加关闭空闲连接，可以及时回收资源；删除多余代码

### DIFF
--- a/client/rest/rest_client.go
+++ b/client/rest/rest_client.go
@@ -25,7 +25,7 @@ const (
 	//DefaultKeepAliveSecond defines the connection time
 	DefaultKeepAliveSecond = 60 * time.Second
 	//DefaultMaxConnsPerHost defines the maximum number of concurrent connections
-	DefaultMaxConnsPerHost = 512
+	DefaultMaxConnsPerHost = 512 * 20
 	//SchemaHTTP represents the http schema
 	SchemaHTTP = "http"
 	//SchemaHTTPS represents the https schema
@@ -121,8 +121,6 @@ func (c *Client) Call(ctx context.Context, addr string, inv *invocation.Invocati
 		reqSend.URL.Host = addr
 	}
 
-	//increase the max connection per host to prevent error "no free connection available" error while sending more requests.
-	c.c.Transport.(*http.Transport).MaxIdleConnsPerHost = 512 * 20
 	var temp *http.Response
 	errChan := make(chan error, 1)
 	go func() {
@@ -146,8 +144,9 @@ func (c *Client) String() string {
 	return "rest_client"
 }
 
-// Close is noop
+// Close release the idle connection
 func (c *Client) Close() error {
+	c.c.CloseIdleConnections()
 	return nil
 }
 

--- a/client/rest/rest_client_test.go
+++ b/client/rest/rest_client_test.go
@@ -43,7 +43,8 @@ func initEnv() {
 
 func TestNewRestClient_Close(t *testing.T) {
 	initEnv()
-	runtime.ServiceName = "Server"
+	//runtime.ServiceName = "Server"
+	addr := "127.0.0.1:8041"
 	schema := "schema2"
 
 	defaultChain := make(map[string]string)
@@ -58,7 +59,7 @@ func TestNewRestClient_Close(t *testing.T) {
 	assert.NoError(t, err)
 	s := f(
 		server.Options{
-			Address:   "127.0.0.1:8041",
+			Address:   addr,
 			ChainName: "default",
 		})
 	_, err = s.Register(&schemas.RestFulHello{},
@@ -68,26 +69,20 @@ func TestNewRestClient_Close(t *testing.T) {
 	assert.NoError(t, err)
 
 	c, err := rest.NewRestClient(client.Options{})
-	if err != nil {
-		t.Errorf("Unexpected dial err: %v", err)
-	}
+	assert.Nil(t, err)
 
 	reply := rest.NewResponse()
-	arg, _ := rest.NewRequest("GET", "http://Server/instances", nil)
+	arg, _ := rest.NewRequest("POST", "http://Server2/sayhi", nil)
 	req := &invocation.Invocation{
-		MicroServiceName: "Server",
+		MicroServiceName: "Server2",
 		Args:             arg,
 		Metadata:         nil,
 	}
 
-	log.Println("protocol name:", "rest")
-	err = c.Call(context.TODO(), addrRest, req, reply)
-	if err != nil {
-		assert.Error(t, err)
-	} else {
-		assert.NoError(t, err)
-	}
-	log.Println("hellp reply", &reply)
+	t.Log("protocol name:", "rest")
+	err = c.Call(context.TODO(), addr, req, reply)
+	assert.Nil(t, err)
+	t.Logf("help reply: %v", reply)
 
 	err = c.Close()
 	assert.Nil(t, err)
@@ -121,6 +116,7 @@ func TestNewRestClient_Call(t *testing.T) {
 	assert.NoError(t, err)
 
 	c, err := rest.NewRestClient(client.Options{})
+	assert.Nil(t, err)
 	if err != nil {
 		t.Errorf("Unexpected dial err: %v", err)
 	}
@@ -133,14 +129,10 @@ func TestNewRestClient_Call(t *testing.T) {
 		Metadata:         nil,
 	}
 
-	log.Println("protocol name:", "rest")
+	t.Log("protocol name:", "rest")
 	err = c.Call(context.TODO(), addrRest, req, reply)
-	if err != nil {
-		assert.Error(t, err)
-	} else {
-		assert.NoError(t, err)
-	}
-	log.Println("hellp reply", &reply)
+	assert.Nil(t, err)
+	t.Logf("help reply: %v", reply)
 
 	ctx, cancel := context.WithCancel(context.Background())
 
@@ -148,9 +140,8 @@ func TestNewRestClient_Call(t *testing.T) {
 
 	err = c.Call(ctx, addrRest, req, reply)
 	expectedError := client.ErrCanceled
-	if assert.Error(t, err) {
-		assert.Equal(t, expectedError, err)
-	}
+	assert.NotNil(t, err)
+	assert.Equal(t, expectedError, err)
 }
 
 func TestNewRestClient_ParseDurationFailed(t *testing.T) {
@@ -178,9 +169,7 @@ func TestNewRestClient_ParseDurationFailed(t *testing.T) {
 	assert.NoError(t, err)
 
 	c, err := rest.NewRestClient(client.Options{})
-	if err != nil {
-		t.Errorf("Unexpected dial err: %v", err)
-	}
+	assert.Nil(t, err)
 
 	reply := rest.NewResponse()
 	arg, _ := rest.NewRequest("GET", "http://Server1/instances", nil)
@@ -191,15 +180,10 @@ func TestNewRestClient_ParseDurationFailed(t *testing.T) {
 	}
 
 	name := c.String()
-	log.Println("protocol name:", name)
+	t.Log("protocol name: ", name)
 	err = c.Call(context.TODO(), "127.0.0.1:8040", req, reply)
-	log.Println("hellp reply", reply)
-	if err != nil {
-		assert.Error(t, err)
-	} else {
-		assert.NoError(t, err)
-	}
-
+	t.Logf("hellp reply: %v", reply)
+	assert.Nil(t, err)
 }
 
 func TestNewRestClient_Call_Error_Scenarios(t *testing.T) {


### PR DESCRIPTION
1.为Client增加关闭空闲连接，可以及时回收资源；
2.删除多余代码