### PR TITLE
Add keyfile field in options

### DIFF
--- a/storage/options.go
+++ b/storage/options.go
@@ -8,6 +8,7 @@ type Options struct {
 	RootCA     string `yaml:"rootCAFile"`
 	Timeout    string `yaml:"timeout"`
 	VerifyPeer bool   `yaml:"verifyPeer"`
+	KeyFile    string `yaml:"keyFile"`
 }
 
 type Option func(opt *Options)
@@ -39,6 +40,12 @@ func Timeout(timeout string) Option {
 func VerifyPeer(verifyPeer bool) Option {
 	return func(opt *Options) {
 		opt.VerifyPeer = verifyPeer
+	}
+}
+
+func KeyFile(keyFile string) Option {
+	return func(opt *Options) {
+		opt.KeyFile = keyFile
 	}
 }
 


### PR DESCRIPTION
Set to the path of the file that contains the TLS/SSL certificate and key.