### PR TITLE
bugfix: able to handler string value

### DIFF
--- a/control/servicecomb/qps_event_listener.go
+++ b/control/servicecomb/qps_event_listener.go
@@ -1,14 +1,14 @@
 package servicecomb
 
 import (
-	"fmt"
 	"github.com/go-chassis/go-archaius/event"
 	"github.com/go-chassis/go-chassis/v2/resilience/rate"
 	"github.com/go-chassis/openlog"
+	"strconv"
 
-	"strings"
-
+	"fmt"
 	"github.com/go-chassis/go-chassis/v2/core/common"
+	"strings"
 )
 
 //QPSEventListener is a struct used for Event listener
@@ -24,9 +24,23 @@ func (el *QPSEventListener) Event(e *event.Event) {
 	if strings.Contains(e.Key, "enabled") {
 		return
 	}
+	if e.Value == nil {
+		openlog.Error(fmt.Sprintf("nil qps value %s", e.Key))
+		return
+	}
 	qps, ok := e.Value.(int)
 	if !ok {
-		openlog.Error(fmt.Sprintf("invalid qps config %s", e.Value))
+		var err error
+		qpsString, ok := e.Value.(string)
+		if !ok {
+			openlog.Error(fmt.Sprintf("invalid qps config %s", e.Value))
+			return
+		}
+		qps, err = strconv.Atoi(qpsString)
+		if err != nil {
+			openlog.Error(fmt.Sprintf("invalid qps config %s", e.Value))
+			return
+		}
 	}
 	openlog.Info("update rate limiter", openlog.WithTags(openlog.Tags{
 		"module": "RateLimiting",

--- a/control/servicecomb/qps_event_listener_test.go
+++ b/control/servicecomb/qps_event_listener_test.go
@@ -18,5 +18,9 @@ func TestQpsEvent(t *testing.T) {
 
 	e2 := &event.Event{EventType: "DELETE", Key: "cse.flowcontrol.Consumer.qps.limit.Server", Value: 199}
 	eventListen.Event(e2)
+	t.Run("given rate in string, should be valid", func(t *testing.T) {
+		e3 := &event.Event{EventType: "DELETE", Key: "cse.flowcontrol.Consumer.qps.limit.Server", Value: "299"}
+		eventListen.Event(e3)
+	})
 
 }


### PR DESCRIPTION
限流配置下发有可能int被当做string处理
而老的实现没有在出现问题后返回，所以导致限流一直为0，服务服务访问，修复方式：支持string格式的变量，无法转为int立刻返回