### PR TITLE
decouple archaius from protocol plugin impl

### DIFF
--- a/core/server/options.go
+++ b/core/server/options.go
@@ -17,6 +17,12 @@ type Options struct {
 	BodyLimit          int64
 	HeaderLimit        int
 	Timeout            time.Duration
+
+	ProfilingEnable bool
+	ProfilingAPI    string
+
+	MetricsEnable bool
+	MetricsAPI    string
 }
 
 //RegisterOptions is options when you register a schema to chassis

--- a/core/server/server_manager.go
+++ b/core/server/server_manager.go
@@ -3,6 +3,7 @@ package server
 import (
 	"errors"
 	"fmt"
+	"github.com/go-chassis/go-archaius"
 	"log"
 	"time"
 
@@ -15,6 +16,12 @@ import (
 	"github.com/go-chassis/go-chassis/v2/pkg/util"
 	"github.com/go-chassis/go-chassis/v2/pkg/util/iputil"
 	"github.com/go-chassis/openlog"
+)
+
+// constants for server
+const (
+	DefaultMetricPath  = "metrics"
+	DefaultProfilePath = "profile"
 )
 
 //NewFunc returns a ProtocolServer
@@ -137,6 +144,10 @@ func initialServer(providerMap map[string]string, p model.Protocol, name string)
 		TLSConfig:          tlsConfig,
 		BodyLimit:          config.GlobalDefinition.ServiceComb.Transport.MaxBodyBytes[protocolName],
 		HeaderLimit:        config.GlobalDefinition.ServiceComb.Transport.MaxHeaderBytes[protocolName],
+		ProfilingAPI:       archaius.GetString("servicecomb.profile.apiPath", DefaultProfilePath),
+		ProfilingEnable:    archaius.GetBool("servicecomb.profile.enable", false),
+		MetricsAPI:         archaius.GetString("servicecomb.metrics.apiPath", DefaultMetricPath),
+		MetricsEnable:      archaius.GetBool("servicecomb.metrics.enable", false),
 	}
 	if t := config.GlobalDefinition.ServiceComb.Transport.Timeout[protocolName]; len(t) > 0 {
 		timeout, err := time.ParseDuration(t)

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	github.com/cenkalti/backoff v2.0.0+incompatible
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/emicklei/go-restful v2.12.0+incompatible
-	github.com/go-chassis/cari v0.0.0-20201210041921-7b6fbef2df11
+	github.com/go-chassis/cari v0.3.0
 	github.com/go-chassis/foundation v0.3.0
 	github.com/go-chassis/go-archaius v1.5.1
 	github.com/go-chassis/go-restful-swagger20 v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -45,6 +45,7 @@ github.com/davecgh/go-spew v0.0.0-20151105211317-5215b55f46b2/go.mod h1:J7Y8YcW2
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/deckarep/golang-set v1.7.1/go.mod h1:93vsz/8Wt4joVM7c2AVqh+YRMiUSc14yDtF28KmMOgQ=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96 h1:cenwrSVm+Z7QLSV/BsnenAOcDXdX4cMv4wP0B/5QbPg=
@@ -66,6 +67,8 @@ github.com/gin-gonic/gin v1.4.0 h1:3tMoCCfM7ppqsR0ptz/wi1impNpT7/9wQtMZ8lr1mCQ=
 github.com/gin-gonic/gin v1.4.0/go.mod h1:OW2EZn3DO8Ln9oIKOvM++LBO+5UPHJJDH72/q/3rZdM=
 github.com/go-chassis/cari v0.0.0-20201210041921-7b6fbef2df11 h1:y3OAHQJZNLZ2R6OmKsjFQqTirRLdgM9WdPSFiTPK3zE=
 github.com/go-chassis/cari v0.0.0-20201210041921-7b6fbef2df11/go.mod h1:MgtsEI0AM4Ush6Lyw27z9Gk4nQ/8GWTSXrFzupawWDM=
+github.com/go-chassis/cari v0.3.0 h1:ysEX1t9dBObshebFKca3zhrWFqyPvcIZo2r66IyJjuk=
+github.com/go-chassis/cari v0.3.0/go.mod h1:Ie2lW11Y5ZFClY9z7bhAwK6BoNxqGSf3fYGs4mPFs74=
 github.com/go-chassis/foundation v0.2.2-0.20201210043510-9f6d3de40234/go.mod h1:2PjwqpVwYEVaAldl5A58a08viH8p27pNeYaiE3ZxOBA=
 github.com/go-chassis/foundation v0.2.2 h1:pu378+kf/NejqgHU9LogU6smWpjs+Mx0S99y27nW8OQ=
 github.com/go-chassis/foundation v0.2.2/go.mod h1:2PjwqpVwYEVaAldl5A58a08viH8p27pNeYaiE3ZxOBA=

--- a/server/restful/restful_server.go
+++ b/server/restful/restful_server.go
@@ -14,7 +14,6 @@ import (
 	"sync"
 
 	"github.com/emicklei/go-restful"
-	"github.com/go-chassis/go-archaius"
 	"github.com/go-chassis/go-chassis/v2/core/common"
 	globalconfig "github.com/go-chassis/go-chassis/v2/core/config"
 	"github.com/go-chassis/go-chassis/v2/core/config/schema"
@@ -31,9 +30,8 @@ import (
 // constants for metric path and name
 const (
 	//Name is a variable of type string which indicates the protocol being used
-	Name                    = "rest"
-	DefaultMetricPath       = "metrics"
-	DefaultProfilePath      = "profile"
+	Name = "rest"
+
 	ProfileRouteRuleSubPath = "route-rule"
 	ProfileDiscoverySubPath = "discovery"
 	MimeFile                = "application/octet-stream"
@@ -56,15 +54,15 @@ type restfulServer struct {
 
 func newRestfulServer(opts server.Options) server.ProtocolServer {
 	ws := new(restful.WebService)
-	if archaius.GetBool("servicecomb.metrics.enable", false) {
-		metricPath := archaius.GetString("servicecomb.metrics.apiPath", DefaultMetricPath)
+	if opts.MetricsEnable {
+		metricPath := opts.MetricsAPI
 		if !strings.HasPrefix(metricPath, "/") {
 			metricPath = "/" + metricPath
 		}
 		openlog.Info("Enabled metrics API on " + metricPath)
 		ws.Route(ws.GET(metricPath).To(api.PrometheusHandleFunc))
 	}
-	addProfileRoutes(ws)
+	addProfileRoutes(ws, opts)
 	return &restfulServer{
 		opts:      opts,
 		container: restful.NewContainer(),
@@ -72,11 +70,11 @@ func newRestfulServer(opts server.Options) server.ProtocolServer {
 	}
 }
 
-func addProfileRoutes(ws *restful.WebService) {
-	if !archaius.GetBool("servicecomb.profile.enable", false) {
+func addProfileRoutes(ws *restful.WebService, opts server.Options) {
+	if !opts.ProfilingEnable {
 		return
 	}
-	profilePath := archaius.GetString("servicecomb.profile.apiPath", DefaultProfilePath)
+	profilePath := opts.ProfilingAPI
 	if !strings.HasPrefix(profilePath, "/") {
 		profilePath = "/" + profilePath
 	}


### PR DESCRIPTION
https://github.com/go-chassis/go-chassis-extension/tree/master/protocol/gin4r 

gin作为插件不该有archaius的学习成本，应该保证archaius不被协议插件的开发者感知，降低门槛