### PR TITLE
feature: Consumer TLS config supports through compensation

### DIFF
--- a/core/tls/tls.go
+++ b/core/tls/tls.go
@@ -73,7 +73,7 @@ func getSSLConfigMap(tag, protocol, svcType, svcName string) map[string]string {
 			result[k] = r
 			sslSet = true
 		}
-                // consumer如果配置了通配 生效级别为全局配置之上 指定配置之下 且不为自己代理的服务设置证书配置
+		// consumer如果配置了通配 生效级别为全局配置之上 指定配置之下 且不为自己代理的服务设置证书配置
 		if common.Consumer == svcType && svcName != config.GlobalDefinition.ServiceComb.ServiceDescription.Name {
 			consumerKey := protocol + "." + common.Consumer + "." + k
 			if c, exist := sslConfigMap[consumerKey]; exist && c != "" {

--- a/core/tls/tls.go
+++ b/core/tls/tls.go
@@ -98,7 +98,7 @@ func getSSLConfigMap(tag, protocol, svcType, svcName string) map[string]string {
 
 // use general TLSConfig
 func useGeneralTLSConfig(svcType, svcName string) bool {
-	return common.Consumer == svcType && svcName != config.MicroserviceDefinition.ServiceDescription.Name
+	return common.Consumer == svcType && svcName != config.GlobalDefinition.ServiceComb.ServiceDescription.Name
 }
 
 func parseSSLConfig(sslConfigMap map[string]string) (*SSLConfig, error) {

--- a/core/tls/tls.go
+++ b/core/tls/tls.go
@@ -73,7 +73,7 @@ func getSSLConfigMap(tag, protocol, svcType, svcName string) map[string]string {
 			result[k] = r
 			sslSet = true
 		}
-        // consumer如果配置了通配 生效级别为全局配置之上 指定配置之下 且不为自己代理的服务设置证书配置
+                // consumer如果配置了通配 生效级别为全局配置之上 指定配置之下 且不为自己代理的服务设置证书配置
 		if common.Consumer == svcType && svcName != config.GlobalDefinition.ServiceComb.ServiceDescription.Name {
 			consumerKey := protocol + "." + common.Consumer + "." + k
 			if c, exist := sslConfigMap[consumerKey]; exist && c != "" {

--- a/core/tls/tls.go
+++ b/core/tls/tls.go
@@ -74,7 +74,7 @@ func getSSLConfigMap(tag, protocol, svcType, svcName string) map[string]string {
 			sslSet = true
 		}
 		// consumer如果配置了通配 生效级别为全局配置之上 指定配置之下 且不为自己代理的服务设置证书配置
-		if common.Consumer == svcType && svcName != config.GlobalDefinition.ServiceComb.ServiceDescription.Name {
+		if useGeneralTLSConfig(svcType, svcName) {
 			consumerKey := protocol + "." + common.Consumer + "." + k
 			if c, exist := sslConfigMap[consumerKey]; exist && c != "" {
 				result[k] = c
@@ -94,6 +94,11 @@ func getSSLConfigMap(tag, protocol, svcType, svcName string) map[string]string {
 	}
 
 	return result
+}
+
+// use general TLSConfig
+func useGeneralTLSConfig(svcType, svcName string) bool {
+	return common.Consumer == svcType && svcName != config.MicroserviceDefinition.ServiceDescription.Name
 }
 
 func parseSSLConfig(sslConfigMap map[string]string) (*SSLConfig, error) {

--- a/docs/user-guides/tls.md
+++ b/docs/user-guides/tls.md
@@ -194,3 +194,18 @@ ssl:
   TLSService.rest.Consumer.serverName: xxx
   TLSService.rest.Provider.verifyPeer: true
 ```
+In most cases, as a consumer, the certificates you use to access multiple services are the same.
+So we provide general configuration to avoid redundant configuration.
+If you need a different certificate to access a service, 
+you can configure it separately in combination with the method described above, 
+and its effective priority is higher than the general configuration
+```yaml
+ssl:
+  rest.Consumer.cipherSuits: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+  rest.Consumer.protocol: TLSv1.2
+  rest.Consumer.caFile: server.crt,xxx.crt
+  rest.Consumer.certFile: client.crt
+  rest.Consumer.keyFile: client.key
+  rest.Consumer.serverName: xxx
+  rest.Provider.verifyPeer: true
+```

--- a/docs/user-guides/tls.md
+++ b/docs/user-guides/tls.md
@@ -192,7 +192,7 @@ ssl:
   TLSService.rest.Consumer.certFile: client.crt
   TLSService.rest.Consumer.keyFile: client.key
   TLSService.rest.Consumer.serverName: xxx
-  TLSService.rest.Provider.verifyPeer: true
+  TLSService.rest.Consumer.verifyPeer: true
 ```
 In most cases, as a consumer, the certificates you use to access multiple services are the same.
 So we provide general configuration to avoid redundant configuration.
@@ -207,5 +207,5 @@ ssl:
   rest.Consumer.certFile: client.crt
   rest.Consumer.keyFile: client.key
   rest.Consumer.serverName: xxx
-  rest.Provider.verifyPeer: true
+  rest.Consumer.verifyPeer: true
 ```


### PR DESCRIPTION
Common certificate in ugly scene ，Consumer TLS configuration supports through compensation；
such as rest.consumer.verifyPeer： xxxxx
https://github.com/go-chassis/go-chassis/issues/979