### PR TITLE
access log 不能进行绕接

### DIFF
--- a/middleware/accesslog/access_log.go
+++ b/middleware/accesslog/access_log.go
@@ -38,13 +38,15 @@ func init() {
 	} else {
 		var err error
 		opts := &lager.Options{
-			Writers:        lager.File,
-			LoggerLevel:    lager.LevelInfo,
-			LoggerFile:     initiator.LoggerOptions.AccessLogFile,
-			LogFormatText:  initiator.LoggerOptions.LogFormatText,
-			LogRotateAge:   initiator.LoggerOptions.LogRotateAge,
-			LogRotateSize:  initiator.LoggerOptions.LogRotateSize,
-			LogBackupCount: initiator.LoggerOptions.LogBackupCount,
+			Writers:           lager.File,
+			LoggerLevel:       lager.LevelInfo,
+			LoggerFile:        initiator.LoggerOptions.AccessLogFile,
+			LogFormatText:     initiator.LoggerOptions.LogFormatText,
+			LogRotateAge:      initiator.LoggerOptions.LogRotateAge,
+			LogRotateSize:     initiator.LoggerOptions.LogRotateSize,
+			LogBackupCount:    initiator.LoggerOptions.LogBackupCount,
+			LogRotateCompress: initiator.LoggerOptions.LogRotateCompress,
+			LogRotateDisable:  initiator.LoggerOptions.LogRotateDisable,
 		}
 		log, err = lager.NewLog(opts)
 		if err != nil {


### PR DESCRIPTION
LogRotateCompress和LogRotateDisable不能传递到seclog
LogRotateCompress为是否开启压缩的参数，默认值为false，不开启
LogRotateDisable为是否开启绕接的参数，默认是开启