### PR TITLE
添加LogColorMode选项；默认打开client endpoint health check

### DIFF
--- a/core/lager/lager.go
+++ b/core/lager/lager.go
@@ -38,6 +38,7 @@ type Options struct {
 	LoggerLevel   string `yaml:"logLevel"`
 	LoggerFile    string `yaml:"logFile"`
 	LogFormatText bool   `yaml:"logFormatText"`
+	LogColorMode  string `yaml:"logColorMode"`
 
 	LogRotateDisable  bool `yaml:"logRotateDisable"`
 	LogRotateCompress bool `yaml:"logRotateCompress"`
@@ -81,6 +82,7 @@ func NewLog(option *Options) (lager.Logger, error) {
 	seclog.Init(seclog.Config{
 		LoggerLevel:   option.LoggerLevel,
 		LogFormatText: option.LogFormatText,
+		LogColorMode:  option.LogColorMode,
 		Writers:       writers,
 		LoggerFile:    logFilePath,
 		RotateDisable: option.LogRotateDisable,
@@ -116,6 +118,9 @@ func checkPassLagerDefinition(option *Options) {
 	}
 	if option.Writers == "" {
 		option.Writers = "file,stdout"
+	}
+	if option.LogColorMode == "" {
+		option.LogColorMode = lager.ColorModeAuto
 	}
 }
 

--- a/core/registry/heartbeat.go
+++ b/core/registry/heartbeat.go
@@ -43,7 +43,14 @@ func (s *HeartbeatService) Stop() {
 
 // DoHeartBeat do heartbeat for each instance
 func (s *HeartbeatService) DoHeartBeat(microServiceID, microServiceInstanceID string, instanceHeartbeatMode string) error {
-	_, err := DefaultRegistrator.Heartbeat(microServiceID, microServiceInstanceID, instanceHeartbeatMode)
+	if instanceHeartbeatMode == PersistenceHeartBeat {
+		f := func() {
+			s.RetryRegister(microServiceID, microServiceInstanceID)
+		}
+		_, err := DefaultRegistrator.WSHeartbeat(microServiceID, microServiceInstanceID, f)
+		return err
+	}
+	_, err := DefaultRegistrator.Heartbeat(microServiceID, microServiceInstanceID)
 	if err != nil {
 		openlog.Error(fmt.Sprintf("heartbeat fail,try to recover, err: %s", err))
 		s.RetryRegister(microServiceID, microServiceInstanceID)

--- a/core/registry/mock/mock.go
+++ b/core/registry/mock/mock.go
@@ -33,8 +33,14 @@ func (m *RegistratorMock) RegisterServiceAndInstance(microService *registry.Micr
 }
 
 // Heartbeat heart beat
-func (m *RegistratorMock) Heartbeat(microServiceID, microServiceInstanceID string, instanceHeartbeatMode string) (bool, error) {
-	args := m.Called(microServiceID, microServiceInstanceID, instanceHeartbeatMode)
+func (m *RegistratorMock) Heartbeat(microServiceID, microServiceInstanceID string) (bool, error) {
+	args := m.Called(microServiceID, microServiceInstanceID)
+	return args.Bool(0), args.Error(1)
+}
+
+// Heartbeat heart beat
+func (m *RegistratorMock) WSHeartbeat(microServiceID, microServiceInstanceID string, callback func()) (bool, error) {
+	args := m.Called(microServiceID, microServiceInstanceID, callback)
 	return args.Bool(0), args.Error(1)
 }
 

--- a/core/registry/registrator.go
+++ b/core/registry/registrator.go
@@ -52,7 +52,8 @@ type Registrator interface {
 	//RegisterServiceInstance register a microservice instance to registry
 	RegisterServiceInstance(sid string, instance *MicroServiceInstance) (string, error)
 	RegisterServiceAndInstance(microService *MicroService, instance *MicroServiceInstance) (string, string, error)
-	Heartbeat(microServiceID, microServiceInstanceID string, instanceHeartbeatMode string) (bool, error)
+	Heartbeat(microServiceID, microServiceInstanceID string) (bool, error)
+	WSHeartbeat(microServiceID, microServiceInstanceID string, callback func()) (bool, error)
 	UnRegisterMicroServiceInstance(microServiceID, microServiceInstanceID string) error
 	UpdateMicroServiceInstanceStatus(microServiceID, microServiceInstanceID, status string) error
 	UpdateMicroServiceProperties(microServiceID string, properties map[string]string) error

--- a/core/registry/servicecenter/servicecenter.go
+++ b/core/registry/servicecenter/servicecenter.go
@@ -96,19 +96,21 @@ func (r *Registrator) UnRegisterMicroServiceInstance(microServiceID, microServic
 	return nil
 }
 
-// Heartbeat : Keep instance heartbeats.
-func (r *Registrator) Heartbeat(microServiceID, microServiceInstanceID string, instanceHeartbeatMode string) (bool, error) {
-	if instanceHeartbeatMode == registry.PersistenceHeartBeat {
-		err := r.registryClient.WSHeartbeat(microServiceID, microServiceInstanceID)
-		if err != nil {
-			openlog.Error(fmt.Sprintf("Heartbeat failed, microServiceID/instanceID: %s/%s. %s",
-				microServiceID, microServiceInstanceID, err))
-			return false, err
-		}
-		openlog.Debug(fmt.Sprintf("heartbeat success, microServiceID/instanceID: %s/%s.",
-			microServiceID, microServiceInstanceID))
-		return true, nil
+// WSHeartbeat : Keep instance heartbeats.
+func (r *Registrator) WSHeartbeat(microServiceID string, microServiceInstanceID string, callback func()) (bool, error) {
+	err := r.registryClient.WSHeartbeat(microServiceID, microServiceInstanceID, callback)
+	if err != nil {
+		openlog.Error(fmt.Sprintf("Heartbeat failed, microServiceID/instanceID: %s/%s. %s",
+			microServiceID, microServiceInstanceID, err))
+		return false, err
 	}
+	openlog.Debug(fmt.Sprintf("heartbeat success, microServiceID/instanceID: %s/%s.",
+		microServiceID, microServiceInstanceID))
+	return true, nil
+}
+
+// Heartbeat : Keep instance heartbeats.
+func (r *Registrator) Heartbeat(microServiceID, microServiceInstanceID string) (bool, error) {
 	// use http
 	bo, err := r.registryClient.Heartbeat(microServiceID, microServiceInstanceID)
 	if err != nil {

--- a/core/registry/servicecenter/servicecenter_test.go
+++ b/core/registry/servicecenter/servicecenter_test.go
@@ -62,11 +62,11 @@ func testRegisterServiceAndInstance(t *testing.T, scc registry.Registrator, sd r
 	assert.NoError(t, err)
 	assert.Equal(t, "test", microservice2.Metadata["test"])
 
-	success, err := scc.Heartbeat(sid, insID, "non-keep-alive")
+	success, err := scc.Heartbeat(sid, insID)
 	assert.Equal(t, success, true)
 	assert.NoError(t, err)
 
-	_, err = scc.Heartbeat("jdfhbh", insID, "non-keep-alive")
+	_, err = scc.Heartbeat("jdfhbh", insID)
 	assert.Error(t, err)
 
 	err = scc.UpdateMicroServiceInstanceStatus(sid, insID, "UP")
@@ -108,11 +108,11 @@ func TestInstanceWSHeartbeat(t *testing.T) {
 		serviceID, instanceID = sid, insID
 	})
 	t.Run("send heartbeat,should success", func(t *testing.T) {
-		success, err := registry.DefaultRegistrator.Heartbeat(serviceID, instanceID, "non-keep-alive")
+		success, err := registry.DefaultRegistrator.Heartbeat(serviceID, instanceID)
 		assert.Equal(t, success, true)
 		assert.NoError(t, err)
 
-		success, err = registry.DefaultRegistrator.Heartbeat(serviceID, instanceID, "ping-pong")
+		success, err = registry.DefaultRegistrator.WSHeartbeat(serviceID, instanceID, func() {})
 		assert.Equal(t, success, true)
 		assert.NoError(t, err)
 	})

--- a/docs/user-guides/log.md
+++ b/docs/user-guides/log.md
@@ -11,6 +11,7 @@
 - logWriters: 表示日志的输出方式，默认为文件和标准输出。
 - logFile: 日志路径
 - logFormatText: 默认为false，即设定日志的输出格式为 json。若为true则输出格式为plaintext，类似log4j。建议使用json格式输出的日志。
+- LogColorMode: 设定日志的输出是否带颜色，auto: 自动，只有writer是stdout是才带颜色；always：带颜色；never：不带颜色；默认auto
 - logRotateDisable: 是否开启日志绕接.
 - logRotateCompress: 是否压缩旧的日志
 - logRotateAge: 日志rotate时间配置，单位"day"，范围为(0, 10)。

--- a/go.mod
+++ b/go.mod
@@ -3,13 +3,13 @@ module github.com/go-chassis/go-chassis/v2
 require (
 	github.com/cenkalti/backoff v2.0.0+incompatible
 	github.com/emicklei/go-restful v2.12.0+incompatible
-	github.com/go-chassis/cari v0.5.0
+	github.com/go-chassis/cari v0.5.1-0.20210823023004-74041d1363c4
 	github.com/go-chassis/foundation v0.3.0
 	github.com/go-chassis/go-archaius v1.5.1
 	github.com/go-chassis/go-restful-swagger20 v1.0.3
 	github.com/go-chassis/openlog v1.1.2
-	github.com/go-chassis/sc-client v0.6.1-0.20210615014358-a45e9090c751
-	github.com/go-chassis/seclog v1.3.0
+	github.com/go-chassis/sc-client v0.6.1-0.20210917073514-7078937694c7
+	github.com/go-chassis/seclog v1.3.1-0.20210917082355-52c40864f240
 	github.com/golang-jwt/jwt v3.2.1+incompatible
 	github.com/golang/protobuf v1.4.2
 	github.com/gorilla/websocket v1.4.3-0.20210424162022-e8629af678b7
@@ -20,7 +20,7 @@ require (
 	github.com/prometheus/common v0.2.0
 	github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a
 	github.com/stretchr/testify v1.6.1
-	gopkg.in/yaml.v2 v2.3.0
+	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/apimachinery v0.17.0
 	k8s.io/client-go v0.17.0
 )

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,7 @@ github.com/Azure/go-autorest/logger v0.1.0/go.mod h1:oExouG+K6PryycPJfVSxi/koC6L
 github.com/Azure/go-autorest/tracing v0.5.0/go.mod h1:r/s2XiOKccPW3HrqB+W0TQzfbtp2fGCgRFtBroKn4Dk=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/BurntSushi/toml v0.4.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/PuerkitoBio/purell v1.0.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
@@ -21,6 +22,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 h1:xJ4a3vCFaGF/jqvzLM
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/cenkalti/backoff v2.0.0+incompatible h1:5IIPUHhlnUZbcHQsQou5k1Tn58nJkeJL9U+ig5CHJbY=
 github.com/cenkalti/backoff v2.0.0+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
+github.com/cenkalti/backoff/v4 v4.1.1 h1:G2HAfAmvm/GcKan2oOQpBXOd2tT2G57ZnZGWa1PxPBQ=
+github.com/cenkalti/backoff/v4 v4.1.1/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/coocood/freecache v1.0.1/go.mod h1:ePwxCDzOYvARfHdr1pByNct1at3CoKnsipOHwKlNbzI=
@@ -47,6 +50,8 @@ github.com/go-chassis/cari v0.4.0 h1:2rJ7pB4dfZIu5/HQwwJhmybC1n/0MXWkKieoHCu4tQc
 github.com/go-chassis/cari v0.4.0/go.mod h1:av/19fqwEP4eOC8unL/z67AAbFDwXUCko6SKa4Avrd8=
 github.com/go-chassis/cari v0.5.0 h1:KMkHtVJuFeqd9NtlcJm27ZBJYhQja909+rgR5CaCs00=
 github.com/go-chassis/cari v0.5.0/go.mod h1:av/19fqwEP4eOC8unL/z67AAbFDwXUCko6SKa4Avrd8=
+github.com/go-chassis/cari v0.5.1-0.20210823023004-74041d1363c4 h1:FTbuN+IqSX17ulICGJqr357o8dGWqtfUdLtztLvIiRI=
+github.com/go-chassis/cari v0.5.1-0.20210823023004-74041d1363c4/go.mod h1:av/19fqwEP4eOC8unL/z67AAbFDwXUCko6SKa4Avrd8=
 github.com/go-chassis/foundation v0.2.2-0.20201210043510-9f6d3de40234/go.mod h1:2PjwqpVwYEVaAldl5A58a08viH8p27pNeYaiE3ZxOBA=
 github.com/go-chassis/foundation v0.2.2/go.mod h1:2PjwqpVwYEVaAldl5A58a08viH8p27pNeYaiE3ZxOBA=
 github.com/go-chassis/foundation v0.3.0 h1:jG4BIrK8fXD9jbTtJ5rOLGQZ1pQI/mLnDuVJzToCtos=
@@ -61,8 +66,12 @@ github.com/go-chassis/openlog v1.1.2 h1:LgGfwwOhpU8c6URV6ADpaRBPVY7Ph1C28jCQ6zzQ
 github.com/go-chassis/openlog v1.1.2/go.mod h1:+eYCADVxWyJkwsFMUBrMxyQlNqW+UUsCxvR2LrYZUaA=
 github.com/go-chassis/sc-client v0.6.1-0.20210615014358-a45e9090c751 h1:hpWN/MZBMsnJqXdMkW7v0wsC+4rYulPsBFMrHCmZMQc=
 github.com/go-chassis/sc-client v0.6.1-0.20210615014358-a45e9090c751/go.mod h1:TBS9g7OaIeu1OR/9tVPJEl6BgHFcYEdbuJlgVDQczbc=
+github.com/go-chassis/sc-client v0.6.1-0.20210917073514-7078937694c7 h1:RXRlKv+b2nIZ26opy/I9l4xlwX0PDt8kNzdZnZAPbO0=
+github.com/go-chassis/sc-client v0.6.1-0.20210917073514-7078937694c7/go.mod h1:njEnGErgKB1aem5slUPzntnS74IduZWLMZFFakzdBnU=
 github.com/go-chassis/seclog v1.3.0 h1:ofjF+GpDd7YFdxa6xk13brZfVSKMdZoQVPoCWjFHGUk=
 github.com/go-chassis/seclog v1.3.0/go.mod h1:a/zGvX5BRiwtq/O0fRqS6VWjrBaXYtqFJBx3EX9xzSE=
+github.com/go-chassis/seclog v1.3.1-0.20210917082355-52c40864f240 h1:sa4aHe3Rsc7DNzkKhsgCNjQi+iYC9gw6ASV+ieLZI54=
+github.com/go-chassis/seclog v1.3.1-0.20210917082355-52c40864f240/go.mod h1:BsV4SB+CpbJnr4QazhUyV4H4gVHbcZiTWxP5XOd4GuA=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
@@ -224,6 +233,7 @@ golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190503192946-f4e77d36d62c/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20191004110552-13f9640d40b9 h1:rjwSpXsdiK0dV8/Naq3kAw9ymfAeJIyd0upUIElB+lI=
 golang.org/x/net v0.0.0-20191004110552-13f9640d40b9/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20201209123823-ac852fbbde11 h1:lwlPPsmjDKK0J6eG6xDWd5XPehI0R024zxjDnw3esPA=
 golang.org/x/net v0.0.0-20201209123823-ac852fbbde11/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
@@ -244,6 +254,7 @@ golang.org/x/sys v0.0.0-20190209173611-3b5209105503/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456 h1:ng0gs1AKnRRuEMZoTLLlbOd+C17zUDepwGQBb/n+JVg=
 golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68 h1:nxC68pudNYkKU6jWhgrqdreuFiOQWj1Fs7T3VrH4Pjw=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -299,6 +310,8 @@ gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=


### PR DESCRIPTION
- 若用户将打印到标准输出的日志重定向到文件，则日志中将带有颜色控制字符。为适配这种使用场景，添加颜色控制选项，允许强制开启、关闭，或自动控制。
- endpoint健康检查是解决“部分endpoint不可用导致调用失败”问题，该问题在普通的调用中就要解决，而非只在endpoint同步时才要解决，因此默认开启。