### PR TITLE
bugfix: Parse services from config failed: input must be an ptr

### DIFF
--- a/control/panel_test.go
+++ b/control/panel_test.go
@@ -40,8 +40,8 @@ func TestInit(t *testing.T) {
 
 func TestNewCircuitCmd(t *testing.T) {
 	config.HystrixConfig = &model.HystrixConfigWrapper{
-		HystrixConfig: model.HystrixConfig{
-			CircuitBreakerProperties: model.CircuitWrapper{
+		HystrixConfig: &model.HystrixConfig{
+			CircuitBreakerProperties: &model.CircuitWrapper{
 				Scope: "",
 			},
 		},

--- a/control/servicecomb/panel_test.go
+++ b/control/servicecomb/panel_test.go
@@ -17,37 +17,37 @@ import (
 
 func init() {
 	config.HystrixConfig = &model.HystrixConfigWrapper{
-		HystrixConfig: model.HystrixConfig{
-			FallbackPolicyProperties: model.FallbackPolicyWrapper{
-				Consumer: model.FallbackPolicySpec{
+		HystrixConfig: &model.HystrixConfig{
+			FallbackPolicyProperties: &model.FallbackPolicyWrapper{
+				Consumer: &model.FallbackPolicySpec{
 					AnyService: map[string]model.FallbackPolicyPropertyStruct{},
 				},
-				Provider: model.FallbackPolicySpec{
+				Provider: &model.FallbackPolicySpec{
 					AnyService: map[string]model.FallbackPolicyPropertyStruct{},
 				},
 			},
-			FallbackProperties: model.FallbackWrapper{
-				Consumer: model.FallbackSpec{
+			FallbackProperties: &model.FallbackWrapper{
+				Consumer: &model.FallbackSpec{
 					AnyService: map[string]model.FallbackPropertyStruct{},
 				},
-				Provider: model.FallbackSpec{
+				Provider: &model.FallbackSpec{
 					AnyService: map[string]model.FallbackPropertyStruct{},
 				},
 			},
-			IsolationProperties: model.IsolationWrapper{
-				Consumer: model.IsolationSpec{
+			IsolationProperties: &model.IsolationWrapper{
+				Consumer: &model.IsolationSpec{
 					AnyService:            map[string]model.IsolationSpec{},
 					MaxConcurrentRequests: 100,
 				},
-				Provider: model.IsolationSpec{
+				Provider: &model.IsolationSpec{
 					AnyService: map[string]model.IsolationSpec{},
 				},
 			},
-			CircuitBreakerProperties: model.CircuitWrapper{
-				Consumer: model.CircuitBreakerSpec{
+			CircuitBreakerProperties: &model.CircuitWrapper{
+				Consumer: &model.CircuitBreakerSpec{
 					AnyService: map[string]model.CircuitBreakPropertyStruct{},
 				},
-				Provider: model.CircuitBreakerSpec{
+				Provider: &model.CircuitBreakerSpec{
 					AnyService: map[string]model.CircuitBreakPropertyStruct{},
 				},
 			},

--- a/core/client/client_manager.go
+++ b/core/client/client_manager.go
@@ -139,7 +139,7 @@ func Close(protocol, service, endpoint string) error {
 }
 
 // SetTimeoutToClientCache set timeout to client
-func SetTimeoutToClientCache(spec model.IsolationWrapper) {
+func SetTimeoutToClientCache(spec *model.IsolationWrapper) {
 	sl.Lock()
 	defer sl.Unlock()
 	for _, client := range clients {

--- a/core/client/client_manager_test.go
+++ b/core/client/client_manager_test.go
@@ -22,9 +22,9 @@ func init() {
 		LoggerLevel: "INFO",
 	})
 	config.HystrixConfig = &model.HystrixConfigWrapper{
-		HystrixConfig: model.HystrixConfig{
-			IsolationProperties: model.IsolationWrapper{
-				Consumer: model.IsolationSpec{},
+		HystrixConfig: &model.HystrixConfig{
+			IsolationProperties: &model.IsolationWrapper{
+				Consumer: &model.IsolationSpec{},
 			},
 		},
 	}
@@ -179,8 +179,8 @@ func TestSetTimeoutToClientCache(t *testing.T) {
 	assert.NotEmpty(t, c)
 	assert.Nil(t, err)
 
-	spec := model.IsolationWrapper{
-		Consumer: model.IsolationSpec{
+	spec := &model.IsolationWrapper{
+		Consumer: &model.IsolationSpec{
 			TimeoutInMilliseconds: config.DefaultTimeout,
 		},
 	}

--- a/core/config/cb_config.go
+++ b/core/config/cb_config.go
@@ -150,28 +150,28 @@ func GetPolicy(service, t string) string {
 	return policy
 }
 
-func getIsolationSpec(command string) model.IsolationSpec {
+func getIsolationSpec(command string) *model.IsolationSpec {
 	if command == common.Consumer {
 		return GetHystrixConfig().IsolationProperties.Consumer
 	}
 	return GetHystrixConfig().IsolationProperties.Provider
 }
 
-func getCircuitBreakerSpec(command string) model.CircuitBreakerSpec {
+func getCircuitBreakerSpec(command string) *model.CircuitBreakerSpec {
 	if command == common.Consumer {
 		return GetHystrixConfig().CircuitBreakerProperties.Consumer
 	}
 	return GetHystrixConfig().CircuitBreakerProperties.Provider
 }
 
-func getFallbackSpec(command string) model.FallbackSpec {
+func getFallbackSpec(command string) *model.FallbackSpec {
 	if command == common.Consumer {
 		return GetHystrixConfig().FallbackProperties.Consumer
 	}
 	return GetHystrixConfig().FallbackProperties.Provider
 }
 
-func getFallbackPolicySpec(command string) model.FallbackPolicySpec {
+func getFallbackPolicySpec(command string) *model.FallbackPolicySpec {
 	if command == common.Consumer {
 		return GetHystrixConfig().FallbackPolicyProperties.Consumer
 	}

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -180,11 +180,12 @@ func ReadMonitorFromArchaius() error {
 
 // ReadHystrixFromArchaius is unmarshal hystrix configuration file(circuit_breaker.yaml)
 func ReadHystrixFromArchaius() error {
-	HystrixConfig = &model.HystrixConfigWrapper{}
-	err := archaius.UnmarshalConfig(&HystrixConfig)
+	hystrixCnf := model.HystrixConfigWrapper{}
+	err := archaius.UnmarshalConfig(&hystrixCnf)
 	if err != nil {
 		return err
 	}
+	HystrixConfig = &hystrixCnf
 	return nil
 }
 
@@ -199,7 +200,7 @@ func GetLoadBalancing() *model.LoadBalancing {
 //GetHystrixConfig return cb config
 func GetHystrixConfig() *model.HystrixConfig {
 	if HystrixConfig != nil {
-		return &HystrixConfig.HystrixConfig
+		return HystrixConfig.HystrixConfig
 	}
 	return nil
 }

--- a/core/config/model/circuit_breaker.go
+++ b/core/config/model/circuit_breaker.go
@@ -6,40 +6,40 @@ import (
 
 // HystrixConfigWrapper hystrix configuration wrapper structure
 type HystrixConfigWrapper struct {
-	HystrixConfig HystrixConfig `yaml:"cse"`
+	HystrixConfig *HystrixConfig `yaml:"cse"`
 }
 
 // HystrixConfig is hystrix configuration structure
 type HystrixConfig struct {
-	IsolationProperties      IsolationWrapper      `yaml:"isolation"`
-	CircuitBreakerProperties CircuitWrapper        `yaml:"circuitBreaker"`
-	FallbackProperties       FallbackWrapper       `yaml:"fallback"`
-	FallbackPolicyProperties FallbackPolicyWrapper `yaml:"fallbackpolicy"`
+	IsolationProperties      *IsolationWrapper      `yaml:"isolation"`
+	CircuitBreakerProperties *CircuitWrapper        `yaml:"circuitBreaker"`
+	FallbackProperties       *FallbackWrapper       `yaml:"fallback"`
+	FallbackPolicyProperties *FallbackPolicyWrapper `yaml:"fallbackpolicy"`
 }
 
 // IsolationWrapper isolation wrapper structure
 type IsolationWrapper struct {
-	Consumer IsolationSpec `yaml:"Consumer"`
-	Provider IsolationSpec `yaml:"Provider"`
+	Consumer *IsolationSpec `yaml:"Consumer"`
+	Provider *IsolationSpec `yaml:"Provider"`
 }
 
 // CircuitWrapper circuit wrapper structure
 type CircuitWrapper struct {
-	Scope    string             `yaml:"scope"`
-	Consumer CircuitBreakerSpec `yaml:"Consumer"`
-	Provider CircuitBreakerSpec `yaml:"Provider"`
+	Scope    string              `yaml:"scope"`
+	Consumer *CircuitBreakerSpec `yaml:"Consumer"`
+	Provider *CircuitBreakerSpec `yaml:"Provider"`
 }
 
 // FallbackWrapper fallback wrapper structure
 type FallbackWrapper struct {
-	Consumer FallbackSpec `yaml:"Consumer"`
-	Provider FallbackSpec `yaml:"Provider"`
+	Consumer *FallbackSpec `yaml:"Consumer"`
+	Provider *FallbackSpec `yaml:"Provider"`
 }
 
 // FallbackPolicyWrapper fallback policy wrapper
 type FallbackPolicyWrapper struct {
-	Consumer FallbackPolicySpec `yaml:"Consumer"`
-	Provider FallbackPolicySpec `yaml:"Provider"`
+	Consumer *FallbackPolicySpec `yaml:"Consumer"`
+	Provider *FallbackPolicySpec `yaml:"Provider"`
 }
 
 // IsolationSpec isolation speciafications


### PR DESCRIPTION
What type of PR is this?

/bugfix

What this PR does / why we need it:

**error**：

![image](https://user-images.githubusercontent.com/27326092/142589232-549a6594-1f32-4f78-a19f-c5b5d8176850.png)


`
{"level":"INFO","timestamp":"2021-11-11 11:37:58.989 +08:00","file":"servicecomb/transfer.go:118","msg":"save circuit breaker config [hystrix.CommandConfig{MaxConcurrentRequests:100, RequestVolumeThreshold:20, SleepWindow:10000, ErrorPercentThreshold:10, ForceFallback:false, CircuitBreakerEnabled:false, ForceOpen:false, ForceClose:false, MetricsConsumerNum:0}] for [] "}
{"level":"INFO","timestamp":"2021-11-11 11:37:58.990 +08:00","file":"servicecomb/transfer.go:118","msg":"save circuit breaker config [hystrix.CommandConfig{MaxConcurrentRequests:1000, RequestVolumeThreshold:20, SleepWindow:15000, ErrorPercentThreshold:50, ForceFallback:false, CircuitBreakerEnabled:false, ForceOpen:false, ForceClose:false, MetricsConsumerNum:0}] for [] "}
{"level":"ERROR","timestamp":"2021-11-11 11:37:58.990 +08:00","file":"servicecomb/transfer.go:181","msg":"Parse services from config failed: input must be an ptr"}
{"level":"ERROR","timestamp":"2021-11-11 11:37:58.991 +08:00","file":"servicecomb/transfer.go:186","msg":"Parse services from config failed: input must be an ptr"}
{"level":"ERROR","timestamp":"2021-11-11 11:37:58.991 +08:00","file":"servicecomb/transfer.go:181","msg":"Parse services from config failed: input must be an ptr"}
{"level":"ERROR","timestamp":"2021-11-11 11:37:58.994 +08:00","file":"servicecomb/transfer.go:186","msg":"Parse services from config failed: input must be an ptr"}
{"level":"ERROR","timestamp":"2021-11-11 11:37:58.995 +08:00","file":"servicecomb/transfer.go:181","msg":"Parse services from config failed: input must be an ptr"}
{"level":"ERROR","timestamp":"2021-11-11 11:37:58.997 +08:00","file":"servicecomb/transfer.go:186","msg":"Parse services from config failed: input must be an ptr"}
{"level":"ERROR","timestamp":"2021-11-11 11:37:58.998 +08:00","file":"servicecomb/transfer.go:181","msg":"Parse services from config failed: input must be an ptr"}
{"level":"ERROR","timestamp":"2021-11-11 11:37:58.998 +08:00","file":"servicecomb/transfer.go:186","msg":"Parse services from config failed: input must be an ptr"}
{"level":"INFO","timestamp":"2021-11-11 11:37:58.998 +08:00","file":"tracing/tracer_manager.go:37","msg":"Tracing enabled. Start to init tracer."}
`

Which issue(s) this PR fixes:

Fixes #1013 

without ptr error
![image](https://user-images.githubusercontent.com/27326092/142589872-fc76339f-b9d5-4bf5-a043-e5f6bd5042a0.png)


Special notes for your reviewer: @tianxiaoliang  


Does this PR introduce a user-facing change?

No

Additional documentation e.g., usage docs, etc.:

No