### PR TITLE
refactor quota management

### DIFF
--- a/pkg/backends/quota/manage_test.go
+++ b/pkg/backends/quota/manage_test.go
@@ -27,18 +27,22 @@ import (
 type inMemory struct {
 }
 
-func (im *inMemory) IncreaseUsed(service, domain, project, resource string, used int64) error {
+func (im *inMemory) SetLimit(domain, project, resourceType string, limit int64) error {
+	panic("implement me")
+}
+
+func (im *inMemory) IncreaseUsed(domain, project, resource string, used int64) error {
 	return nil
 }
-func (im *inMemory) DecreaseUsed(service, domain, project, resource string, used int64) error {
+func (im *inMemory) DecreaseUsed(domain, project, resource string, used int64) error {
 	return nil
 }
-func (im *inMemory) GetQuota(service, domain, project, resource string) (*quota.Quota, error) {
-	return &quota.Quota{ResourceName: "cpu", Used: 10, Limit: 20}, nil
+func (im *inMemory) GetQuota(domain, project, resource string) (*quota.Quota, error) {
+	return &quota.Quota{ResourceType: "cpu", Used: 10, Limit: 20}, nil
 }
-func (im *inMemory) GetQuotas(service, domain, project string) ([]*quota.Quota, error) {
+func (im *inMemory) GetQuotas(domain, project string) ([]*quota.Quota, error) {
 	return []*quota.Quota{
-		{ResourceName: "cpu", Used: 10, Limit: 20}, {ResourceName: "mem", Used: 10, Limit: 256},
+		{ResourceType: "cpu", Used: 10, Limit: 20}, {ResourceType: "mem", Used: 10, Limit: 256},
 	}, nil
 }
 func TestInit(t *testing.T) {
@@ -50,7 +54,7 @@ func TestInit(t *testing.T) {
 			Plugin:   "",
 		})
 		assert.NoError(t, err)
-		err = quota.PreCreate("", "", "", "some", 1)
+		err = quota.PreCreate("", "", "some", 1)
 		assert.NoError(t, err)
 	})
 	t.Run("install and init", func(t *testing.T) {
@@ -64,15 +68,15 @@ func TestInit(t *testing.T) {
 		assert.NoError(t, err)
 	})
 	t.Run("pre create,should success", func(t *testing.T) {
-		err := quota.PreCreate("", "", "", "cpu", 2)
+		err := quota.PreCreate("", "", "cpu", 2)
 		assert.NoError(t, err)
 	})
 	t.Run("pre create reached maximum,should success", func(t *testing.T) {
-		err := quota.PreCreate("", "", "", "cpu", 12)
+		err := quota.PreCreate("", "", "cpu", 12)
 		assert.Error(t, err)
 	})
 	t.Run("no limits", func(t *testing.T) {
-		err := quota.PreCreate("", "", "", "other", 12)
+		err := quota.PreCreate("", "", "other", 12)
 		assert.NoError(t, err)
 	})
 

--- a/pkg/backends/quota/manager.go
+++ b/pkg/backends/quota/manager.go
@@ -62,37 +62,39 @@ func Init(opts Options) error {
 //defaultManager is manage quotas
 var defaultManager Manager
 
-// Rate describe quota infos
+// Quota describe quota infos
 type Quota struct {
-	ResourceName string
+	ResourceType string
 	Limit        int64
 	Used         int64
 	Unit         string
 }
 
-//Manager could be a quota management system
+//Manager could be a quota management system as a remote service, which saves and manages all of your system resources.
+// or it could be a module of your service which manage quota saved in database
 type Manager interface {
-	GetQuota(service, domain, project, resource string) (*Quota, error)
-	GetQuotas(service, domain, project string) ([]*Quota, error)
-	IncreaseUsed(service, domain, project, resource string, used int64) error
-	DecreaseUsed(service, domain, project, resource string, used int64) error
+	GetQuota(domain, project, resourceType string) (*Quota, error)
+	GetQuotas(domain, project string) ([]*Quota, error)
+	IncreaseUsed(domain, project, resourceType string, used int64) error
+	DecreaseUsed(domain, project, resourceType string, used int64) error
+	SetLimit(domain, project, resourceType string, limit int64) error
 }
 
-//PreCreate only check quota usage before creating a resource for a domain/tenant and project.
-//is will not increase resource usage number after check, you have to increase after resource actually created
-func PreCreate(service, domain, project, resource string, number int64) error {
+//PreCreate only check quota usage before creating a resource for a domain(tenant) and project.
+//it will not increase resource usage number after check, you have to increase after resource actually created
+func PreCreate(domain, project, resource string, number int64) error {
 	if defaultManager == nil {
-		openlog.Debug("quota management not available")
+		openlog.Warn("quota management not available, fallback")
 		return nil
 	}
-	qs, err := defaultManager.GetQuotas(service, domain, project)
+	qs, err := defaultManager.GetQuotas(domain, project)
 	if err != nil {
 		openlog.Error(err.Error())
 		return ErrGetFailed
 	}
 	var resourceQuota *Quota
 	for _, q := range qs {
-		if q.ResourceName == resource {
+		if q.ResourceType == resource {
 			resourceQuota = q
 			break
 		}

--- a/pkg/backends/quota/options.go
+++ b/pkg/backends/quota/options.go
@@ -19,6 +19,10 @@ package quota
 
 //Options is init options
 type Options struct {
-	Endpoint string
-	Plugin   string
+	// optional, namespace for resourceType,
+	// for example you service provide cpu resource. but other service has a resourceType also use name cpu,
+	// then you need to separate them by namespace
+	Namespace string
+	Endpoint  string //optional
+	Plugin    string //required
 }


### PR DESCRIPTION
- 增加覆盖配额的方法，方便业务使用
- service的设计考虑不全面，实际上大部分的场景下service并发必选项，重命名为namespace，并放到option中，有需要的业务可以考虑集成
- 统一resource的命名为resourceType