### PR TITLE
fix test: clean up log dir after test complete

### DIFF
--- a/core/lager/lager_test.go
+++ b/core/lager/lager_test.go
@@ -1,21 +1,23 @@
 package lager_test
 
 import (
-	"github.com/go-chassis/go-chassis/v2/core/lager"
-	"github.com/go-chassis/openlog"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/go-chassis/go-chassis/v2/core/lager"
+	"github.com/go-chassis/openlog"
 )
 
 func TestInitialize1(t *testing.T) {
+	logDir := t.TempDir()
 	lager.Init(&lager.Options{
-		LoggerFile: filepath.Join("./log", "chassis.log"),
+		LoggerFile: filepath.Join(logDir, "chassis.log"),
 		Writers:    "file",
 	})
 
-	if _, err := os.Stat("log"); err != nil {
+	if _, err := os.Stat(logDir); err != nil {
 		if os.IsNotExist(err) {
 			t.Error(err)
 		}
@@ -26,9 +28,9 @@ func TestInitialize1(t *testing.T) {
 }
 
 func TestInitialize2(t *testing.T) {
-	path := os.Getenv("GOPATH")
-	logDir := filepath.Join(path, "src", "github.com", "go-chassis", "go-chassis", "examples", "discovery", "server")
-	os.Setenv("CHASSIS_HOME", logDir)
+	homeDir := t.TempDir()
+	os.Setenv("CHASSIS_HOME", homeDir)
+	logDir := filepath.Join(homeDir, "log")
 
 	//initializing config for to initialize PassLagerDefinition variable
 	t.Log("initializing config for to initialize PassLagerDefinition variable")


### PR DESCRIPTION
Found core/lager/lager_test.go does not clean up log dir after test complete.
Check if function t.Cleanup(added in go1.14) is allowed to use before merge.
ref: [t.Cleanup](https://pkg.go.dev/testing#T.Cleanup)
Thx!