### PR TITLE
fix test: exec Unsetenv after test complete

### DIFF
--- a/bootstrap/bootstrap_test.go
+++ b/bootstrap/bootstrap_test.go
@@ -21,8 +21,11 @@ type bootstrapPlugin struct {
 	Name string
 }
 
-func initialize() {
+func initialize(t *testing.T) {
 	os.Setenv("CHASSIS_HOME", "/tmp/")
+	t.Cleanup(func() {
+		os.Unsetenv("CHASSIS_HOME")
+	})
 	chassisConf := filepath.Join("/tmp/", "conf")
 	os.MkdirAll(chassisConf, 0700)
 	os.Create(filepath.Join(chassisConf, "chassis.yaml"))
@@ -35,7 +38,7 @@ func (b *bootstrapPlugin) Init() error {
 }
 
 func TestBootstrap(t *testing.T) {
-	initialize()
+	initialize(t)
 	config.Init()
 	time.Sleep(1 * time.Second)
 	config.GlobalDefinition = &model.GlobalCfg{}

--- a/chassis_api_test.go
+++ b/chassis_api_test.go
@@ -12,9 +12,10 @@ import (
 	"github.com/go-chassis/go-chassis/v2/core/server"
 	"github.com/go-chassis/go-chassis/v2/pkg/util/fileutil"
 
+	"syscall"
+
 	"github.com/go-chassis/go-chassis/v2/core/config/model"
 	"github.com/stretchr/testify/assert"
-	"syscall"
 )
 
 const (
@@ -26,9 +27,10 @@ func TestInit(t *testing.T) {
 	defer syscall.Umask(mask)
 	t.Log("Testing Chassis Init function")
 	os.Setenv("CHASSIS_HOME", filepath.Join(os.Getenv("GOPATH"), "test", "chassisInit"))
+	defer os.Unsetenv("CHASSIS_HOME")
 	err := os.MkdirAll(fileutil.GetConfDir(), 0700)
 	assert.NoError(t, err)
-	globalDefFile, err := os.OpenFile(fileutil.GlobalConfigPath(), os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0700)
+	globalDefFile, _ := os.OpenFile(fileutil.GlobalConfigPath(), os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0700)
 	defer globalDefFile.Close()
 
 	// write some text line-by-line to file
@@ -85,7 +87,7 @@ ssl:
 	msDefFile, err := os.OpenFile(fileutil.MicroServiceConfigPath(), os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0700)
 	assert.NoError(t, err)
 	defer msDefFile.Close()
-	_, err = msDefFile.WriteString(`---
+	msDefFile.WriteString(`---
 #微服务的私有属性
 servicecomb:
   service:
@@ -145,6 +147,7 @@ func TestInitError(t *testing.T) {
 	t.Log("Testing chassis Init function for errors")
 	p := filepath.Join(os.Getenv("GOPATH"), "src", "github.com", "go-chassis", "go-chassis", "examples", "communication/client")
 	os.Setenv("CHASSIS_HOME", p)
+	defer os.Unsetenv("CHASSIS_HOME")
 
 	lager.Init(&lager.Options{
 		LoggerLevel: "INFO",

--- a/control/servicecomb/panel_test.go
+++ b/control/servicecomb/panel_test.go
@@ -1,6 +1,9 @@
 package servicecomb_test
 
 import (
+	"os"
+	"testing"
+
 	"github.com/go-chassis/go-archaius"
 	"github.com/go-chassis/go-chassis/v2/control"
 	_ "github.com/go-chassis/go-chassis/v2/control/servicecomb"
@@ -11,8 +14,6 @@ import (
 	"github.com/go-chassis/go-chassis/v2/core/loadbalancer"
 	_ "github.com/go-chassis/go-chassis/v2/initiator"
 	"github.com/stretchr/testify/assert"
-	"os"
-	"testing"
 )
 
 func init() {
@@ -123,6 +124,7 @@ func TestPanel_GetLoadBalancing(t *testing.T) {
 func BenchmarkPanel_GetLoadBalancing(b *testing.B) {
 	gopath := os.Getenv("GOPATH")
 	os.Setenv("CHASSIS_HOME", gopath+"/src/github.com/go-chassis/go-chassis/v2/examples/discovery/client/")
+	defer os.Unsetenv("CHASSIS_HOME")
 	config.Init()
 	config.GlobalDefinition.Panel.Infra = "archaius"
 	opts := control.Options{
@@ -141,6 +143,7 @@ func BenchmarkPanel_GetLoadBalancing(b *testing.B) {
 func BenchmarkPanel_GetLoadBalancing2(b *testing.B) {
 	gopath := os.Getenv("GOPATH")
 	os.Setenv("CHASSIS_HOME", gopath+"/src/github.com/go-chassis/go-chassis/v2/examples/discovery/client/")
+	defer os.Unsetenv("CHASSIS_HOME")
 	config.Init()
 	config.GlobalDefinition.Panel.Infra = "archaius"
 	opts := control.Options{
@@ -161,6 +164,7 @@ func BenchmarkPanel_GetLoadBalancing2(b *testing.B) {
 func BenchmarkPanel_GetCircuitBreaker(b *testing.B) {
 	gopath := os.Getenv("GOPATH")
 	os.Setenv("CHASSIS_HOME", gopath+"/src/github.com/go-chassis/go-chassis/v2/examples/discovery/client/")
+	defer os.Unsetenv("CHASSIS_HOME")
 	config.Init()
 	config.GlobalDefinition.Panel.Infra = "archaius"
 	opts := control.Options{
@@ -181,6 +185,7 @@ func BenchmarkPanel_GetCircuitBreaker(b *testing.B) {
 func BenchmarkPanel_GetRateLimiting(b *testing.B) {
 	gopath := os.Getenv("GOPATH")
 	os.Setenv("CHASSIS_HOME", gopath+"/src/github.com/go-chassis/go-chassis/v2/examples/discovery/client/")
+	defer os.Unsetenv("CHASSIS_HOME")
 	config.Init()
 	config.GlobalDefinition.Panel.Infra = "archaius"
 	opts := control.Options{

--- a/core/config/cb_config_test.go
+++ b/core/config/cb_config_test.go
@@ -6,13 +6,14 @@ import (
 
 	_ "github.com/go-chassis/go-chassis/v2/initiator"
 
+	"io"
+	"path/filepath"
+	"time"
+
 	"github.com/go-chassis/go-chassis/v2/core/common"
 	"github.com/go-chassis/go-chassis/v2/core/config"
 	"github.com/go-chassis/go-chassis/v2/pkg/util/fileutil"
 	"github.com/stretchr/testify/assert"
-	"io"
-	"path/filepath"
-	"time"
 )
 
 func TestCBInit(t *testing.T) {
@@ -106,6 +107,7 @@ servicecomb:
 	assert.NoError(t, err)
 
 	os.Setenv(fileutil.ChassisConfDir, d)
+	defer os.Unsetenv(fileutil.ChassisConfDir)
 	err = config.Init()
 	assert.NoError(t, err)
 

--- a/core/config/cd_config_test.go
+++ b/core/config/cd_config_test.go
@@ -8,11 +8,12 @@ import (
 
 	"github.com/go-chassis/go-chassis/v2/core/config"
 
-	"github.com/go-chassis/go-chassis/v2/pkg/util/fileutil"
-	"github.com/stretchr/testify/assert"
 	"io"
 	"path/filepath"
 	"time"
+
+	"github.com/go-chassis/go-chassis/v2/pkg/util/fileutil"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestCDInit(t *testing.T) {
@@ -52,6 +53,7 @@ servicecomb:
 	assert.NoError(t, err)
 
 	os.Setenv(fileutil.ChassisConfDir, d)
+	defer os.Unsetenv(fileutil.ChassisConfDir)
 	err = config.Init()
 	assert.NoError(t, err)
 
@@ -89,6 +91,7 @@ servicecomb:
 		defer f1.Close()
 
 		os.Setenv(fileutil.ChassisConfDir, d)
+		defer os.Unsetenv(fileutil.ChassisConfDir)
 		time.Sleep(1 * time.Second)
 		config.ReadGlobalConfigFromArchaius()
 		check := config.GetContractDiscoveryType()

--- a/core/config/config_test.go
+++ b/core/config/config_test.go
@@ -3,16 +3,17 @@ package config_test
 import (
 	"testing"
 
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+
 	"github.com/go-chassis/go-chassis/v2/core/config"
 	"github.com/go-chassis/go-chassis/v2/core/config/model"
 	"github.com/go-chassis/go-chassis/v2/core/loadbalancer"
 	"github.com/go-chassis/go-chassis/v2/pkg/util/fileutil"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v2"
-	"io"
-	"os"
-	"path/filepath"
-	"time"
 )
 
 func TestInit1(t *testing.T) {
@@ -63,6 +64,7 @@ servicecomb:
 	assert.NoError(t, err)
 
 	os.Setenv(fileutil.ChassisConfDir, d)
+	defer os.Unsetenv(fileutil.ChassisConfDir)
 	err = config.Init()
 	assert.NoError(t, err)
 	time.Sleep(1 * time.Second)
@@ -182,7 +184,10 @@ cse:
 
 func TestInitErrorWithBlankEnv(t *testing.T) {
 	os.Setenv("CHASSIS_HOME", "")
+	defer os.Unsetenv("CHASSIS_HOME")
 	os.Setenv("CHASSIS_CONF_DIR", "")
+	defer os.Unsetenv("CHASSIS_CONF_DIR")
+
 	err := config.Init()
 	t.Log(err)
 	assert.Error(t, err)

--- a/core/config/schema/loader_test.go
+++ b/core/config/schema/loader_test.go
@@ -1,14 +1,15 @@
 package schema
 
 import (
+	"os"
+	"path/filepath"
+	"testing"
+
 	"github.com/emicklei/go-restful"
 	"github.com/go-chassis/go-chassis/v2/pkg/runtime"
 	"github.com/go-chassis/go-chassis/v2/pkg/util/fileutil"
 	swagger "github.com/go-chassis/go-restful-swagger20"
 	"github.com/stretchr/testify/assert"
-	"os"
-	"path/filepath"
-	"testing"
 )
 
 func TestLoadSchema(t *testing.T) {
@@ -27,6 +28,7 @@ func TestLoadSchema(t *testing.T) {
 
 	//Fix the root directory otherwise the Schema dir will be created inside /tmp/go-buildXXX///
 	os.Setenv("CHASSIS_HOME", os.Getenv("GOPATH"))
+	defer os.Unsetenv("CHASSIS_HOME")
 
 	schemaDirOfMs1 := fileutil.SchemaDir(microserviceName1)
 
@@ -66,6 +68,7 @@ func TestLoadSchema(t *testing.T) {
 func TestSetSchemaIDs(t *testing.T) {
 	p := os.Getenv("GOPATH")
 	os.Setenv("CHASSIS_HOME", filepath.Join(p, "src", "github.com", "go-chassis", "go-chassis", "examples", "discovery", "server"))
+	defer os.Unsetenv("CHASSIS_HOME")
 	config := swagger.Config{
 		WebServices: restful.DefaultContainer.RegisteredWebServices(),
 		OpenService: true,

--- a/core/handler/handler_chain_test.go
+++ b/core/handler/handler_chain_test.go
@@ -1,6 +1,11 @@
 package handler_test
 
 import (
+	"log"
+	"os"
+	"path/filepath"
+	"testing"
+
 	"github.com/go-chassis/go-chassis/v2/core/common"
 	"github.com/go-chassis/go-chassis/v2/core/config"
 	"github.com/go-chassis/go-chassis/v2/core/config/model"
@@ -8,10 +13,6 @@ import (
 	"github.com/go-chassis/go-chassis/v2/core/invocation"
 	"github.com/go-chassis/go-chassis/v2/core/lager"
 	"github.com/stretchr/testify/assert"
-	"log"
-	"os"
-	"path/filepath"
-	"testing"
 )
 
 func init() {
@@ -49,6 +50,7 @@ func TestCreateChain(t *testing.T) {
 func BenchmarkChain_Next(b *testing.B) {
 	path := os.Getenv("GOPATH")
 	os.Setenv("CHASSIS_HOME", filepath.Join(path, "src", "github.com", "go-chassis", "go-chassis", "examples", "discovery", "client"))
+	defer os.Unsetenv("CHASSIS_HOME")
 	config.GlobalDefinition = &model.GlobalCfg{}
 	config.Init()
 	iv := &invocation.Invocation{}

--- a/core/handler/handler_test.go
+++ b/core/handler/handler_test.go
@@ -1,6 +1,11 @@
 package handler_test
 
 import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
 	"github.com/go-chassis/go-chassis/v2/core/common"
 	"github.com/go-chassis/go-chassis/v2/core/config"
 	"github.com/go-chassis/go-chassis/v2/core/config/model"
@@ -11,10 +16,6 @@ import (
 	"github.com/go-chassis/go-chassis/v2/pkg/util/fileutil"
 	"github.com/go-chassis/openlog"
 	"github.com/stretchr/testify/assert"
-	"io"
-	"os"
-	"path/filepath"
-	"testing"
 )
 
 func prepareConfDir(t *testing.T) string {
@@ -154,6 +155,7 @@ func TestGetChain(t *testing.T) {
 func BenchmarkPool_GetChain(b *testing.B) {
 	path := os.Getenv("GOPATH")
 	os.Setenv("CHASSIS_HOME", filepath.Join(path, "src", "github.com", "go-chassis", "go-chassis", "examples", "discovery", "client"))
+	defer os.Unsetenv("CHASSIS_HOME")
 	config.GlobalDefinition = &model.GlobalCfg{}
 	config.Init()
 	config.GlobalDefinition.ServiceComb.Handler.Chain.Consumer = map[string]string{

--- a/core/handler/loadbalance_handler_test.go
+++ b/core/handler/loadbalance_handler_test.go
@@ -25,7 +25,7 @@ import (
 	_ "github.com/go-chassis/go-chassis/v2/initiator"
 	"github.com/go-chassis/go-chassis/v2/pkg/runtime"
 	"github.com/go-chassis/go-chassis/v2/pkg/util/fileutil"
-	"github.com/go-chassis/go-chassis/v2/pkg/util/tags"
+	utiltags "github.com/go-chassis/go-chassis/v2/pkg/util/tags"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -509,6 +509,7 @@ func init() {
 func BenchmarkLBHandler_Handle(b *testing.B) {
 	p := os.Getenv("GOPATH")
 	os.Setenv("CHASSIS_HOME", filepath.Join(p, "src", "github.com", "go-chassis", "go-chassis", "examples", "discovery", "client"))
+	defer os.Unsetenv("CHASSIS_HOME")
 	config.Init()
 	opts := control.Options{
 		Infra:   config.GlobalDefinition.Panel.Infra,

--- a/core/invocation/invocation_test.go
+++ b/core/invocation/invocation_test.go
@@ -2,9 +2,10 @@ package invocation_test
 
 import (
 	"context"
+	"testing"
+
 	"github.com/go-chassis/go-chassis/v2/core/invocation"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestChain(t *testing.T) {
@@ -77,6 +78,7 @@ func (h *transportHandler) Handle(c *handler.Chain, i *invocation.Invocation, cb
 func TestChain(t *testing.T) {
 	p := os.Getenv("GOPATH")
 	os.Setenv("CHASSIS_HOME", filepath.Join(p, "src", "github.com", "go-chassis", "go-chassis", "examples", "communication", "client"))
+	defer os.Unsetenv("CHASSIS_HOME")
 	lager.Initialize()
 	config.Init()
 	c := &handler.Chain{}
@@ -113,6 +115,7 @@ func TestChain(t *testing.T) {
 func BenchmarkChainNext(b *testing.B) {
 	p := os.Getenv("GOPATH")
 	os.Setenv("CHASSIS_HOME", filepath.Join(p, "src", "github.com", "go-chassis", "go-chassis", "examples", "communication", "client"))
+	defer os.Unsetenv("CHASSIS_HOME")
 	lager.Initialize()
 	config.Init()
 	c := &handler.Chain{}

--- a/core/lager/lager_test.go
+++ b/core/lager/lager_test.go
@@ -30,6 +30,7 @@ func TestInitialize1(t *testing.T) {
 func TestInitialize2(t *testing.T) {
 	homeDir := t.TempDir()
 	os.Setenv("CHASSIS_HOME", homeDir)
+	defer os.Unsetenv("CHASSIS_HOME")
 	logDir := filepath.Join(homeDir, "log")
 
 	//initializing config for to initialize PassLagerDefinition variable

--- a/core/loadbalancer/loadbalancer_test.go
+++ b/core/loadbalancer/loadbalancer_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/go-chassis/go-chassis/v2/core/registry"
 	_ "github.com/go-chassis/go-chassis/v2/core/registry/servicecenter"
 	"github.com/go-chassis/go-chassis/v2/pkg/runtime"
-	"github.com/go-chassis/go-chassis/v2/pkg/util/tags"
+	utiltags "github.com/go-chassis/go-chassis/v2/pkg/util/tags"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -93,6 +93,7 @@ func TestBuildStrategy(t *testing.T) {
 		},
 	}
 	os.Setenv("HTTP_DEBUG", "1")
+	defer os.Unsetenv("HTTP_DEBUG")
 	registry.Enable()
 	registry.DoRegister()
 	t.Log("System init finished")

--- a/core/registry/servicecenter/cache_test.go
+++ b/core/registry/servicecenter/cache_test.go
@@ -1,17 +1,18 @@
 package servicecenter_test
 
 import (
-	"github.com/go-chassis/go-archaius"
-	"github.com/go-chassis/sc-client"
 	"os"
 	"testing"
 	"time"
+
+	"github.com/go-chassis/go-archaius"
+	"github.com/go-chassis/sc-client"
 
 	"github.com/go-chassis/go-chassis/v2/core/config"
 	"github.com/go-chassis/go-chassis/v2/core/lager"
 	"github.com/go-chassis/go-chassis/v2/core/registry"
 	"github.com/go-chassis/go-chassis/v2/pkg/runtime"
-	"github.com/go-chassis/go-chassis/v2/pkg/util/tags"
+	utiltags "github.com/go-chassis/go-chassis/v2/pkg/util/tags"
 	_ "github.com/go-chassis/go-chassis/v2/security/cipher/plugins/plain"
 	"github.com/hashicorp/go-version"
 	"github.com/stretchr/testify/assert"
@@ -28,6 +29,7 @@ func init() {
 	archaius.Set("servicecomb.service.name", "Server")
 	archaius.Set("servicecomb.service.hostname", "localhost")
 	os.Setenv("HTTP_DEBUG", "1")
+	defer os.Unsetenv("HTTP_DEBUG")
 	config.ReadGlobalConfigFromArchaius()
 }
 func TestCacheManager_AutoSync(t *testing.T) {

--- a/core/registry/servicecenter/client_test.go
+++ b/core/registry/servicecenter/client_test.go
@@ -1,17 +1,18 @@
 package servicecenter_test
 
 import (
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
 	"github.com/go-chassis/go-chassis/v2/core/config"
 	"github.com/go-chassis/go-chassis/v2/core/lager"
 	_ "github.com/go-chassis/go-chassis/v2/security/cipher/plugins/plain"
 	"github.com/go-chassis/openlog"
 	"github.com/go-chassis/sc-client"
 	"github.com/stretchr/testify/assert"
-	"net/url"
-	"os"
-	"path/filepath"
-	"strings"
-	"testing"
 )
 
 func init() {
@@ -22,6 +23,7 @@ func init() {
 func TestRegistryClient_Health(t *testing.T) {
 	p := os.Getenv("GOPATH")
 	os.Setenv("CHASSIS_HOME", filepath.Join(p, "src", "github.com", "go-chassis", "go-chassis", "examples", "discovery", "server"))
+	defer os.Unsetenv("CHASSIS_HOME")
 	config.Init()
 	registryClient, err := sc.NewClient(
 		sc.Options{

--- a/core/registry/servicecenter/servicecenter_test.go
+++ b/core/registry/servicecenter/servicecenter_test.go
@@ -1,6 +1,10 @@
 package servicecenter_test
 
 import (
+	"os"
+	"path/filepath"
+	"testing"
+
 	scregistry "github.com/go-chassis/cari/discovery"
 	"github.com/go-chassis/go-chassis/v2/core/config"
 	"github.com/go-chassis/go-chassis/v2/core/lager"
@@ -11,9 +15,6 @@ import (
 	_ "github.com/go-chassis/go-chassis/v2/security/cipher/plugins/plain"
 	"github.com/go-chassis/sc-client"
 	"github.com/stretchr/testify/assert"
-	"os"
-	"path/filepath"
-	"testing"
 )
 
 func init() {
@@ -24,6 +25,7 @@ func init() {
 func TestServicecenter_RegisterServiceAndInstance(t *testing.T) {
 	p := os.Getenv("GOPATH")
 	os.Setenv("CHASSIS_HOME", filepath.Join(p, "src", "github.com", "go-chassis", "go-chassis", "examples", "discovery", "server"))
+	defer os.Unsetenv("CHASSIS_HOME")
 	t.Log("Test servercenter.go")
 	config.Init()
 	runtime.Init()

--- a/core/router/router_test.go
+++ b/core/router/router_test.go
@@ -2,11 +2,12 @@ package router_test
 
 import (
 	"context"
-	"github.com/go-chassis/go-chassis/v2/core/marker"
 	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/go-chassis/go-chassis/v2/core/marker"
 
 	"github.com/go-chassis/go-chassis/v2/core/lager"
 
@@ -28,6 +29,7 @@ func init() {
 func TestBuildRouter(t *testing.T) {
 	path := os.Getenv("GOPATH")
 	os.Setenv("CHASSIS_HOME", filepath.Join(path, "src", "github.com", "go-chassis", "go-chassis", "examples", "discovery", "server"))
+	defer os.Unsetenv("CHASSIS_HOME")
 
 	config.Init()
 	router.BuildRouter("cse")

--- a/core/tls/tls_test.go
+++ b/core/tls/tls_test.go
@@ -15,6 +15,7 @@ import (
 
 func TestInit(t *testing.T) {
 	os.Setenv("CHASSIS_HOME", "/tmp")
+	defer os.Unsetenv("CHASSIS_HOME")
 
 	archaius.Init(archaius.WithMemorySource())
 	archaius.Set("ssl.test.Consumer.certFile", "test.cer")

--- a/middleware/circuit/bizkeeper_handler_test.go
+++ b/middleware/circuit/bizkeeper_handler_test.go
@@ -158,6 +158,7 @@ func BenchmarkBizKeepConsumerHandler_Handler(b *testing.B) {
 	c.AddHandler(&circuit.BizKeeperConsumerHandler{})
 	gopath := os.Getenv("GOPATH")
 	os.Setenv("CHASSIS_HOME", gopath+"/src/github.com/go-chassis/go-chassis/v2/examples/discovery/client/")
+	defer os.Unsetenv("CHASSIS_HOME")
 
 	config.Init()
 	opts := control.Options{

--- a/middleware/ratelimiter/qps_consumer_flow_control_handler_test.go
+++ b/middleware/ratelimiter/qps_consumer_flow_control_handler_test.go
@@ -69,6 +69,7 @@ func TestConsumerRateLimiterDisable(t *testing.T) {
 	t.Log("testing consumerratelimiter handler with qps enabled as false")
 	gopath := os.Getenv("GOPATH")
 	os.Setenv("CHASSIS_HOME", gopath+"/src/github.com/go-chassis/go-chassis/v2/examples/discovery/server/")
+	defer os.Unsetenv("CHASSIS_HOME")
 
 	config.Init()
 	opts := control.Options{

--- a/pkg/util/fileutil/fileutil_test.go
+++ b/pkg/util/fileutil/fileutil_test.go
@@ -12,41 +12,55 @@ import (
 
 func TestGetWorkDirHmNotSet(t *testing.T) {
 	os.Setenv("CHASSIS_HOME", "test")
+	defer os.Unsetenv("CHASSIS_HOME")
 	assert.Equal(t, "conf", filepath.Base(fileutil.GetConfDir()))
 
 }
 func TestGetWorkDir(t *testing.T) {
 	os.Setenv("CHASSIS_HOME", "test")
+	defer os.Unsetenv("CHASSIS_HOME")
 	assert.Equal(t, "conf", filepath.Base(fileutil.GetConfDir()))
 }
 
 func TestHystricDefinaiton(t *testing.T) {
 	os.Setenv("CHASSIS_HOME", "test")
+	defer os.Unsetenv("CHASSIS_HOME")
 	def := fileutil.CircuitBreakerConfigPath()
 	assert.Equal(t, filepath.Join("test", "conf", fileutil.Hystric), def)
 }
 func TestMicroserviceDefinition(t *testing.T) {
+	os.Setenv("CHASSIS_HOME", "test")
+	defer os.Unsetenv("CHASSIS_HOME")
 	def := fileutil.MicroserviceDefinition("micro")
 	assert.Equal(t, filepath.Join("test", "conf", "micro", fileutil.Definition), def)
 }
 func TestGlobalDefinition(t *testing.T) {
+	os.Setenv("CHASSIS_HOME", "test")
+	defer os.Unsetenv("CHASSIS_HOME")
 	def := fileutil.GlobalConfigPath()
 	assert.Equal(t, filepath.Join("test", "conf", fileutil.Global), def)
 }
 func TestPassLagerDefinition(t *testing.T) {
+	os.Setenv("CHASSIS_HOME", "test")
+	defer os.Unsetenv("CHASSIS_HOME")
 	def := fileutil.LogConfigPath()
 	assert.Equal(t, filepath.Join("test", "conf", fileutil.PaasLager), def)
 }
 func TestSchemaDir(t *testing.T) {
+	os.Setenv("CHASSIS_HOME", "test")
+	defer os.Unsetenv("CHASSIS_HOME")
 	def := fileutil.SchemaDir("micro")
 	assert.Equal(t, filepath.Join("test", "conf", "micro", fileutil.SchemaDirectory), def)
 }
 func TestGetDefinition(t *testing.T) {
+	os.Setenv("CHASSIS_HOME", "test")
+	defer os.Unsetenv("CHASSIS_HOME")
 	def := fileutil.GetDefinition()
 	assert.Equal(t, filepath.Join("test", "conf", fileutil.Definition), def)
 }
 func TestGetWorkDirConfSet(t *testing.T) {
 	os.Setenv("CHASSIS_CONF_DIR", "conf")
+	defer os.Unsetenv("CHASSIS_CONF_DIR")
 	assert.Equal(t, "conf", filepath.Base(fileutil.GetConfDir()))
 }
 

--- a/security/cipher/plugins/aes/aes.go
+++ b/security/cipher/plugins/aes/aes.go
@@ -2,8 +2,9 @@ package aes
 
 import (
 	"fmt"
-	"github.com/go-chassis/go-chassis/v2/security/cipher"
 	"os"
+
+	"github.com/go-chassis/go-chassis/v2/security/cipher"
 
 	"github.com/go-chassis/cari/security"
 	"github.com/go-chassis/go-chassis/v2/pkg/goplugin"


### PR DESCRIPTION
To avoid one test influence another with Setenv, suggest to add defer to cleanup env  var setting in test.

Before go1.17:
``` golang
os.Setenv("CHASSIS_HOME", "test")
defer os.Unsetenv("CHASSIS_HOME")
```
go1.17 and later:
```golang
func (t *T) Setenv(key, value string)
````
https://pkg.go.dev/testing#T.Setenv
https://cs.opensource.google/go/go/+/go1.18:src/testing/testing.go;l=1280