### PR TITLE
allow logRotateAge option to be set to 0

### DIFF
--- a/core/lager/lager.go
+++ b/core/lager/lager.go
@@ -12,7 +12,7 @@ import (
 
 // constant values for log rotate parameters
 const (
-	LogRotateDate  = 1
+	LogRotateDate  = 0
 	LogRotateSize  = 10
 	LogBackupCount = 7
 )
@@ -105,7 +105,7 @@ func checkPassLagerDefinition(option *Options) {
 		option.LoggerFile = "log/chassis.log"
 	}
 
-	if option.LogRotateAge <= 0 || option.LogRotateAge > 10 {
+	if option.LogRotateAge < 0 || option.LogRotateAge > 10 {
 		option.LogRotateAge = LogRotateDate
 	}
 

--- a/core/lager/lager.go
+++ b/core/lager/lager.go
@@ -12,7 +12,7 @@ import (
 
 // constant values for log rotate parameters
 const (
-	LogRotateDate  = 0
+	LogRotateDate  = 1
 	LogRotateSize  = 10
 	LogBackupCount = 7
 )


### PR DESCRIPTION
此次变更将提供设置日志文件不老化的选项，也即LogRotateAge=0
以前情况：不设置老化天数LogRotateAge或者设置LogRotateAge=0，系统将默认设置LogRotateAge=1，也即老化天数默认为1天