### PR TITLE
new feature: able to observe API pattern and method name

### DIFF
--- a/core/common/common.go
+++ b/core/common/common.go
@@ -108,9 +108,10 @@ const (
 	HeaderMark = "X-Mark"
 )
 
+// Rest metadata key for restful protocol
 const (
-	// RestMethod is the http method for restful protocol
-	RestMethod = "method"
+	RestMethod    = "method"
+	RestRoutePath = "url_pattern"
 )
 
 // constant for default application name and version

--- a/core/invocation/invocation.go
+++ b/core/invocation/invocation.go
@@ -49,7 +49,9 @@ type Invocation struct {
 
 	SchemaID    string // correspond struct name
 	OperationID string // correspond func name of struct
-	URLPath     string // relative API path of http request
+
+	// relative API path of http request
+	URLPath string
 
 	// it holds native request of protocol, use http protocol for example,
 	// it is *http.request

--- a/middleware/monitoring/handler.go
+++ b/middleware/monitoring/handler.go
@@ -19,14 +19,13 @@ package monitoring
 
 import (
 	"fmt"
-	"github.com/emicklei/go-restful"
+	"github.com/go-chassis/go-chassis/v2/core/common"
 	"github.com/go-chassis/go-chassis/v2/core/handler"
 	"github.com/go-chassis/go-chassis/v2/core/invocation"
 	"github.com/go-chassis/go-chassis/v2/core/status"
 	"github.com/go-chassis/go-chassis/v2/pkg/metrics"
 	"github.com/go-chassis/go-chassis/v2/pkg/runtime"
 	"github.com/go-chassis/openlog"
-	"net/http"
 	"time"
 )
 
@@ -38,9 +37,8 @@ const (
 	Name           = "monitoring"
 )
 
-var labels = []string{"service", "instance", "version", "app", "env"}
-var labels4Resp = []string{"service", "instance", "version", "app", "env", "code"}
-var labelMap map[string]string
+var labels = []string{"service", "instance", "version", "app", "env", "API", "method"}
+var labels4Resp = []string{"service", "instance", "version", "app", "env", "code", "API", "method"}
 
 // Handler monitor server side metrics, the key metrics is latency, QPS, Errors, do not use it in consumer chain
 type Handler struct {
@@ -49,22 +47,31 @@ type Handler struct {
 // Handle record metrics
 func (ph *Handler) Handle(chain *handler.Chain, i *invocation.Invocation, cb invocation.ResponseCallBack) {
 	start := time.Now()
-	switch i.Args.(type) {
-	case *http.Request:
-		err := metrics.CounterAdd(MetricsRequest, 1, labelMap)
-		if err != nil {
-			openlog.Error("can not monitor:" + err.Error())
-		}
-	case *restful.Request:
-		err := metrics.CounterAdd(MetricsRequest, 1, labelMap)
-		if err != nil {
-			openlog.Error("can not monitor:" + err.Error())
-		}
-	default:
+	path, ok := i.Metadata[common.RestRoutePath].(string)
+	if !ok {
+		path = "default"
+	}
+	method, ok := i.Metadata[common.RestMethod].(string)
+	if !ok {
+		method = "default"
+	}
+	labelMap := map[string]string{
+		"service":  runtime.ServiceName,
+		"instance": runtime.InstanceID,
+		"version":  runtime.Version,
+		"app":      runtime.App,
+		"env":      runtime.Environment,
+		"API":      path,
+		"method":   method,
+	}
+	err := metrics.CounterAdd(MetricsRequest, 1, labelMap)
+	if err != nil {
+		openlog.Error("can not monitor:" + err.Error())
 		//skip monitoring
 		chain.Next(i, cb)
 		return
 	}
+
 	chain.Next(i, func(resp *invocation.Response) {
 		if resp.Status >= status.Status(i.Protocol, status.InternalServerError) {
 			m := map[string]string{
@@ -74,6 +81,8 @@ func (ph *Handler) Handle(chain *handler.Chain, i *invocation.Invocation, cb inv
 				"app":      runtime.App,
 				"env":      runtime.Environment,
 				"code":     fmt.Sprintf("%d", resp.Status),
+				"API":      path,
+				"method":   method,
 			}
 			err := metrics.CounterAdd(MetricsErrors, 1, m)
 			if err != nil {
@@ -90,35 +99,26 @@ func (ph *Handler) Handle(chain *handler.Chain, i *invocation.Invocation, cb inv
 
 }
 func newHandler() handler.Handler {
-	err := metrics.CreateCounter(metrics.CounterOpts{
+	if err := metrics.CreateCounter(metrics.CounterOpts{
 		Name:   MetricsRequest,
 		Labels: labels,
-	})
-	if err != nil {
+	}); err != nil {
 		openlog.Fatal(err.Error())
 	}
-	err = metrics.CreateSummary(metrics.SummaryOpts{
+	if err := metrics.CreateSummary(metrics.SummaryOpts{
 		Name:       MetricsLatency,
 		Labels:     labels,
 		Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
-	})
-	if err != nil {
+	}); err != nil {
 		openlog.Fatal(err.Error())
 	}
-	err = metrics.CreateCounter(metrics.CounterOpts{
+	if err := metrics.CreateCounter(metrics.CounterOpts{
 		Name:   MetricsErrors,
 		Labels: labels4Resp,
-	})
-	if err != nil {
+	}); err != nil {
 		openlog.Fatal(err.Error())
 	}
-	labelMap = map[string]string{
-		"service":  runtime.ServiceName,
-		"instance": runtime.InstanceID,
-		"version":  runtime.Version,
-		"app":      runtime.App,
-		"env":      runtime.Environment,
-	}
+
 	return &Handler{}
 }
 

--- a/server/restful/restful_server.go
+++ b/server/restful/restful_server.go
@@ -120,7 +120,8 @@ func HTTPRequest2Invocation(req *restful.Request, schema, operation string, resp
 		OperationID:        operation,
 		URLPath:            req.Request.URL.Path,
 		Metadata: map[string]interface{}{
-			common.RestMethod: req.Request.Method,
+			common.RestMethod:    req.Request.Method,
+			common.RestRoutePath: req.SelectedRoute(),
 		},
 	}
 	//set headers to Ctx, then user do not  need to consider about protocol in handlers
@@ -168,7 +169,7 @@ func (r *restfulServer) Register(schema interface{}, options ...server.RegisterO
 // Invocation2HTTPRequest convert invocation back to http request, set down all meta data
 func Invocation2HTTPRequest(inv *invocation.Invocation, req *restful.Request) {
 	for k, v := range inv.Metadata {
-		req.SetAttribute(k, v.(string))
+		req.SetAttribute(k, v)
 	}
 	m := common.FromContext(inv.Ctx)
 	for k, v := range m {


### PR DESCRIPTION
monitoring middleware 不再只能监控http 请求，而是以invocation作为唯一标准模型，实现了真正的协议实现和框架实现无关